### PR TITLE
feat(admission): add support for ValidatingAdmissionPolicy and Mutati…

### DIFF
--- a/.github/workflows/e2e_admission.yaml
+++ b/.github/workflows/e2e_admission.yaml
@@ -1,0 +1,88 @@
+name: E2E Admission
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+  pull_request:
+
+jobs:
+  e2e_admission_policy:
+    runs-on: ubuntu-24.04
+    name: E2E about Admission Policy
+    timeout-minutes: 50
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+
+      - name: Install musl
+        run: |
+          wget http://musl.libc.org/releases/musl-1.2.1.tar.gz
+          tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
+          ./configure
+          make && sudo make install
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Install dependences
+        run: |
+          GO111MODULE="on" go install sigs.k8s.io/kind@v0.29.0
+          curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
+
+      - name: Run E2E Tests
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/e2e-admission-logs
+          make e2e-test-admission-policy CC=/usr/local/musl/bin/musl-gcc
+
+      - name: Upload e2e admission logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: volcano_e2e_admission_policy_logs
+          path: ${{ github.workspace }}/e2e-admission-logs
+  e2e_admission_webhook:
+    runs-on: ubuntu-24.04
+    name: E2E about Admission Webhook
+    timeout-minutes: 50
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+
+      - name: Install musl
+        run: |
+          wget http://musl.libc.org/releases/musl-1.2.1.tar.gz
+          tar -xf musl-1.2.1.tar.gz && cd musl-1.2.1
+          ./configure
+          make && sudo make install
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Install dependences
+        run: |
+          GO111MODULE="on" go install sigs.k8s.io/kind@v0.29.0
+          curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
+
+      - name: Run E2E Tests
+        run: |
+          export ARTIFACTS_PATH=${{ github.workspace }}/e2e-admission-logs
+          make e2e-test-admission-webhook CC=/usr/local/musl/bin/musl-gcc
+
+      - name: Upload e2e admission logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: volcano_e2e_admission_webhook_logs
+          path: ${{ github.workspace }}/e2e-admission-logs

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,12 @@ e2e-test-dra: images
 e2e-test-hypernode: images
 	E2E_TYPE=HYPERNODE ./hack/run-e2e-kind.sh
 
+e2e-test-admission-webhook: images
+	E2E_TYPE=ADMISSION_WEBHOOK ./hack/run-e2e-kind.sh
+
+e2e-test-admission-policy: images
+	E2E_TYPE=ADMISSION_POLICY ./hack/run-e2e-kind.sh
+
 generate-yaml: init manifests
 	./hack/generate-yaml.sh CRD_VERSION=${CRD_VERSION}
 
@@ -217,6 +223,16 @@ update-development-yaml:
 	mv installer/volcano-${TAG}.yaml installer/volcano-development.yaml
 	mv installer/volcano-agent-${TAG}.yaml installer/volcano-agent-development.yaml
 	mv installer/volcano-monitoring-${TAG}.yaml installer/volcano-monitoring.yaml
+
+	ENABLE_VAP=true make generate-yaml RELEASE_DIR=installer
+	mv installer/volcano-${TAG}.yaml installer/volcano-development-vap.yaml
+	rm installer/volcano-agent-${TAG}.yaml
+	rm installer/volcano-monitoring-${TAG}.yaml
+
+	ENABLE_VAP=true ENABLE_MAP=true make generate-yaml RELEASE_DIR=installer
+	mv installer/volcano-${TAG}.yaml installer/volcano-development-vap-map.yaml
+	rm installer/volcano-agent-${TAG}.yaml
+	rm installer/volcano-monitoring-${TAG}.yaml
 
 mod-download-go:
 	@-GOFLAGS="-mod=readonly" find -name go.mod -execdir go mod download \;

--- a/hack/e2e-kind-config.yaml
+++ b/hack/e2e-kind-config.yaml
@@ -4,6 +4,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 featureGates:
   DynamicResourceAllocation: true
   DRAResourceClaimDeviceStatus: true
+  MutatingAdmissionPolicy: true
 containerdConfigPatches:
   # Enable CDI as described in
   # https://tags.cncf.io/container-device-interface#containerd-configuration
@@ -23,7 +24,8 @@ nodes:
         kind: ClusterConfiguration
         apiServer:
           extraArgs:
-            runtime-config: "resource.k8s.io/v1beta1=true"
+            runtime-config: "resource.k8s.io/v1beta1=true,admissionregistration.k8s.io/v1alpha1"
+            enable-admission-plugins: "MutatingAdmissionPolicy"
   # the four workers
   - role: worker
   - role: worker

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -98,6 +98,98 @@ function install-volcano {
   echo "Ensure create namespace"
   kubectl apply -f installer/namespace.yaml
 
+case ${E2E_TYPE} in
+"ADMISSION_POLICY")
+  echo "Install volcano chart with crd version $crd_version and VAP/MAP enabled"
+  cat <<EOF | helm install ${CLUSTER_NAME} installer/helm/chart/volcano \
+  --namespace ${NAMESPACE} \
+  --kubeconfig ${KUBECONFIG} \
+  --values - \
+  --wait
+basic:
+  image_pull_policy: IfNotPresent
+  image_tag_version: ${TAG}
+  scheduler_config_file: config/volcano-scheduler-ci.conf
+  crd_version: ${crd_version}
+
+custom:
+  scheduler_log_level: 5
+  admission_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  controller_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  scheduler_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  default_ns:
+    node-role.kubernetes.io/control-plane: ""
+  scheduler_feature_gates: ${FEATURE_GATES}
+  enabled_admissions: ""
+  vap_enable: true
+  map_enable: true
+  ignored_provisioners: ${IGNORED_PROVISIONERS:-""}
+EOF
+  ;;
+"ADMISSION_WEBHOOK")
+  echo "Install volcano chart with crd version $crd_version and all webhook"
+  cat <<EOF | helm install ${CLUSTER_NAME} installer/helm/chart/volcano \
+  --namespace ${NAMESPACE} \
+  --kubeconfig ${KUBECONFIG} \
+  --values - \
+  --wait
+basic:
+  image_pull_policy: IfNotPresent
+  image_tag_version: ${TAG}
+  scheduler_config_file: config/volcano-scheduler-ci.conf
+  crd_version: ${crd_version}
+
+custom:
+  scheduler_log_level: 5
+  admission_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  controller_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  scheduler_tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+  default_ns:
+    node-role.kubernetes.io/control-plane: ""
+  scheduler_feature_gates: ${FEATURE_GATES}
+  enabled_admissions: "/pods/mutate,/queues/mutate,/podgroups/mutate,/jobs/mutate,/jobs/validate,/jobflows/validate,/pods/validate,/queues/validate,/podgroups/validate,/hypernodes/validate,/cronjobs/validate"
+  vap_enable: false
+  map_enable: false
+  ignored_provisioners: ${IGNORED_PROVISIONERS:-""}
+EOF
+  ;;
+*)
   echo "Install volcano chart with crd version $crd_version"
   cat <<EOF | helm install ${CLUSTER_NAME} installer/helm/chart/volcano \
   --namespace ${NAMESPACE} \
@@ -136,8 +228,11 @@ custom:
   default_ns:
     node-role.kubernetes.io/control-plane: ""
   scheduler_feature_gates: ${FEATURE_GATES}
+  enabled_admissions: "/pods/mutate,/queues/mutate,/podgroups/mutate,/jobs/mutate,/jobs/validate,/jobflows/validate,/pods/validate,/queues/validate,/podgroups/validate,/hypernodes/validate,/cronjobs/validate"
   ignored_provisioners: ${IGNORED_PROVISIONERS:-""}
 EOF
+  ;;
+esac
 }
 
 function uninstall-volcano {
@@ -205,6 +300,7 @@ case ${E2E_TYPE} in
     KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/vcctl/
     KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/cronjob/
     KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress --focus="DRA E2E Test" ./test/e2e/dra/
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/admission/
     KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -r --slow-spec-threshold='30s' --progress ./test/e2e/hypernode/
     ;;
 "JOBP")
@@ -234,6 +330,14 @@ case ${E2E_TYPE} in
 "DRA")
     echo "Running dra e2e suite..."
     KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress --focus="DRA E2E Test" ./test/e2e/dra/
+    ;;
+"ADMISSION_POLICY")
+    echo "Running admission policy e2e suite..."
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress ./test/e2e/admission/
+    ;;
+"ADMISSION_WEBHOOK")
+    echo "Running admission webhook e2e suite..."
+    KUBECONFIG=${KUBECONFIG} GOOS=${OS} ginkgo -v -r --slow-spec-threshold='30s' --progress ./test/e2e/admission/
     ;;
 "HYPERNODE")
     echo "Creating 8 kwok nodes for 3-tier topology"

--- a/installer/helm/chart/volcano/policy/hypernodes-validating.yaml
+++ b/installer/helm/chart/volcano/policy/hypernodes-validating.yaml
@@ -1,0 +1,137 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: hypernode-validation-policy
+  labels:
+    volcano.sh/component: hypernode-webhook
+    volcano.sh/migration: vap
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["topology.volcano.sh"]
+        apiVersions: ["v1alpha1"]
+        resources: ["hypernodes"]
+  variables:
+    # Count how many selector types are defined for each member
+    - name: membersWithSelectorCounts
+      expression: |
+        has(object.spec) && has(object.spec.members) ? 
+        object.spec.members.map(member, 
+          (has(member.selector.exactMatch) ? 1 : 0) + 
+          (has(member.selector.regexMatch) ? 1 : 0) + 
+          (has(member.selector.labelMatch) ? 1 : 0)
+        ) : []
+    # Extract all exactMatch names for validation
+    - name: exactMatchNames
+      expression: |
+        has(object.spec) && has(object.spec.members) ? 
+        object.spec.members
+          .filter(member, has(member.selector.exactMatch))
+          .map(member, member.selector.exactMatch.name) : []
+    # Extract all regexMatch patterns for validation
+    - name: regexMatchPatterns
+      expression: |
+        has(object.spec) && has(object.spec.members) ? 
+        object.spec.members
+          .filter(member, has(member.selector.regexMatch))
+          .map(member, member.selector.regexMatch.pattern) : []
+  validations:
+    # Validate that at least one member is specified
+    - expression: |
+        has(object.spec) && has(object.spec.members) && size(object.spec.members) > 0
+      message: "member must have at least one member"
+      reason: Invalid
+
+    # Validate that each member has at least one selector type
+    - expression: |
+        !has(object.spec) || !has(object.spec.members) || size(object.spec.members) == 0 ||
+        variables.membersWithSelectorCounts.all(count, count >= 1)
+      message: "member selector must have one of exactMatch, regexMatch, or labelMatch"
+      reason: Invalid
+
+    # Validate that each member has no more than one selector type
+    - expression: |
+        !has(object.spec) || !has(object.spec.members) || size(object.spec.members) == 0 ||
+        variables.membersWithSelectorCounts.all(count, count <= 1)
+      message: "cannot specify more than one selector type (exactMatch, regexMatch, labelMatch)"
+      reason: Invalid
+
+    # Validate exactMatch names are not empty
+    - expression: |
+        !has(object.spec) || !has(object.spec.members) || size(object.spec.members) == 0 ||
+        object.spec.members
+          .filter(member, has(member.selector.exactMatch))
+          .all(member, member.selector.exactMatch.name != "")
+      message: "member exactMatch name is required"
+      reason: Invalid
+
+    # Validate exactMatch names follow Kubernetes qualified name rules using CEL format library
+    - expression: |
+        !has(object.spec) || !has(object.spec.members) || size(object.spec.members) == 0 ||
+        variables.exactMatchNames.all(name,
+          !format.qualifiedName().validate(name).hasValue()
+        )
+      message: "member exactMatch validate failed [name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character]"
+      reason: Invalid
+
+    # Validate regexMatch patterns are not empty
+    - expression: |
+        !has(object.spec) || !has(object.spec.members) || size(object.spec.members) == 0 || 
+        object.spec.members
+          .filter(member, has(member.selector.regexMatch))
+          .all(member, member.selector.regexMatch.pattern != "")
+      message: "member regexMatch pattern is required"
+      reason: Invalid
+
+    # Basic regex pattern validation - check for common invalid patterns
+    # Note: CEL doesn't have full regex compilation support, so we do basic checks
+
+    # Check for unmatched parentheses
+    - expression: |
+        !has(object.spec) || !has(object.spec.members) || size(object.spec.members) == 0 ||
+        variables.regexMatchPatterns.all(pattern, 
+          !pattern.contains('(') || 
+          (pattern.split('(').size() == pattern.split(')').size())
+        )
+      message: "member regexMatch pattern is invalid: unmatched parentheses"
+      reason: Invalid
+
+    # Check for unmatched square brackets
+    - expression: |
+        !has(object.spec) || !has(object.spec.members) || size(object.spec.members) == 0 ||
+        variables.regexMatchPatterns.all(pattern, 
+          !pattern.contains('[') || 
+          (pattern.split('[').size() == pattern.split(']').size())
+        )
+      message: "member regexMatch pattern is invalid: unmatched square brackets"
+      reason: Invalid
+
+    # Check for unmatched curly braces
+    - expression: |
+        !has(object.spec) || !has(object.spec.members) || size(object.spec.members) == 0 ||
+        variables.regexMatchPatterns.all(pattern, 
+          !pattern.contains('{') || 
+          (pattern.split('{').size() == pattern.split('}').size())
+        )
+      message: "member regexMatch pattern is invalid: unmatched curly braces"
+      reason: Invalid
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: hypernode-validation-policy-binding
+  labels:
+    volcano.sh/component: hypernode-webhook
+    volcano.sh/migration: vap
+spec:
+  policyName: hypernode-validation-policy
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["topology.volcano.sh"]
+        apiVersions: ["v1alpha1"]
+        resources: ["hypernodes"]

--- a/installer/helm/chart/volcano/policy/jobflows-validating.yaml
+++ b/installer/helm/chart/volcano/policy/jobflows-validating.yaml
@@ -1,0 +1,59 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: jobflow-validation-policy
+  labels:
+    volcano.sh/component: jobflow-webhook
+    volcano.sh/migration: vap
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["flow.volcano.sh"]
+        apiVersions: ["v1alpha1"]
+        resources: ["jobflows"]
+  variables:
+    # Extract flows from the jobflow spec
+    - name: flows
+      expression: "has(object.spec.flows) ? object.spec.flows : []"
+    # Extract flow names for validation
+    - name: flowNames
+      expression: "variables.flows.map(flow, flow.name)"
+  validations:
+    # 1. Valid Dependency References - Dependencies must reference existing flows
+    - expression: |
+        variables.flows.all(flow,
+          !has(flow.dependsOn) ||
+          !has(flow.dependsOn.targets) ||
+          flow.dependsOn.targets.all(target, target in variables.flowNames)
+        )
+      message: "jobflow Flow is not DAG: vertex is not defined"
+      reason: Invalid
+
+    # 2. No Self-Dependencies - A flow cannot depend on itself
+    - expression: |
+        variables.flows.all(flow,
+          !has(flow.dependsOn) ||
+          !has(flow.dependsOn.targets) ||
+          !(flow.name in flow.dependsOn.targets)
+        )
+      message: "jobflow Flow is not DAG"
+      reason: Invalid
+
+  # Note: Complex DAG cycle detection (transitive cycles) is handled by
+  # the validating webhook since CEL expressions cannot implement
+  # full graph traversal algorithms. However, basic validations like
+  # missing references and self-dependencies can be handled here.
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: jobflow-validation-policy-binding
+  labels:
+    volcano.sh/component: jobflow-webhook
+    volcano.sh/migration: vap
+spec:
+  policyName: jobflow-validation-policy
+  validationActions: [Deny]

--- a/installer/helm/chart/volcano/policy/jobs-mutating.yaml
+++ b/installer/helm/chart/volcano/policy/jobs-mutating.yaml
@@ -1,0 +1,123 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: volcano-job-mutation-policy
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: Never
+  matchConstraints:
+    resourceRules:
+    - operations: ["CREATE"]
+      apiGroups: ["batch.volcano.sh"]
+      apiVersions: ["v1alpha1"]
+      resources: ["jobs"]
+  
+  # NOTE: This MutatingAdmissionPolicy provides a PARTIAL replacement for the webhook
+  # implementation. It handles Job-level mutations but CANNOT handle task-level mutations
+  # due to CEL expression limitations in dynamically processing arbitrary numbers of tasks.
+  # 
+  # IMPLEMENTED: Job-level defaults (queue, schedulerName, maxRetry, minAvailable, plugins)
+  # NOT IMPLEMENTED: Task-level defaults (names, minAvailable, maxRetry, DNSPolicy)
+  #
+  # For complete functionality, the existing webhook must remain active alongside this policy.
+  
+  mutations:
+  # Set default queue
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        !has(object.spec.queue) || object.spec.queue == "" ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/queue",
+          value: "default"
+        }] : []
+  
+  # Set default schedulerName  
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        !has(object.spec.schedulerName) || object.spec.schedulerName == "" ?
+        [JSONPatch{
+          op: "add", 
+          path: "/spec/schedulerName",
+          value: "volcano"
+        }] : []
+  
+  # Set default maxRetry
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        !has(object.spec.maxRetry) || object.spec.maxRetry == 0 ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/maxRetry", 
+          value: 3
+        }] : []
+  
+  # Set default minAvailable
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        !has(object.spec.minAvailable) || object.spec.minAvailable == 0 ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/minAvailable",
+          value: object.spec.tasks.map(task, 
+            has(task.minAvailable) && task.minAvailable != null ? 
+            task.minAvailable : task.replicas
+          ).sum()
+        }] : []
+
+  # NOTE: The following task-level mutations are NOT implemented in MutatingAdmissionPolicy
+  # because CEL expressions cannot dynamically iterate over arbitrary number of tasks.
+  # MutatingAdmissionPolicy would require hardcoded rules for each task index (0, 1, 2, etc.)
+  # which is not scalable and differs from the webhook implementation that handles all tasks.
+  # 
+  # Missing task-level mutations that require webhook implementation:
+  # - Set default task names (task0, task1, task2, ...)
+  # - Set default task minAvailable values 
+  # - Set default task maxRetry values
+  # - Set DNSPolicy for tasks using hostNetwork
+  #
+  # These mutations must be handled by the existing webhook for proper functionality.
+
+  # Add svc plugin for distributed frameworks
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        has(object.spec.plugins) && (
+          has(object.spec.plugins.tensorflow) || 
+          has(object.spec.plugins.mpi) || 
+          has(object.spec.plugins.pytorch)
+        ) && !has(object.spec.plugins.svc) ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/plugins/svc",
+          value: []
+        }] : []
+
+  # Add ssh plugin for mpi jobs
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        has(object.spec.plugins) && has(object.spec.plugins.mpi) && 
+        !has(object.spec.plugins.ssh) ?
+        [JSONPatch{
+          op: "add", 
+          path: "/spec/plugins/ssh",
+          value: []
+        }] : []
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: volcano-job-mutation-binding
+spec:
+  policyName: volcano-job-mutation-policy
+  matchResources:
+    resourceRules:
+    - operations: ["CREATE"]
+      apiGroups: ["batch.volcano.sh"] 
+      apiVersions: ["v1alpha1"]
+      resources: ["jobs"]

--- a/installer/helm/chart/volcano/policy/jobs-validating.yaml
+++ b/installer/helm/chart/volcano/policy/jobs-validating.yaml
@@ -1,0 +1,252 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: job-validation-policy
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["batch.volcano.sh"]
+        apiVersions: ["v1alpha1"]
+        resources: ["jobs"]
+  variables:
+    # Extract task names for validation
+    - name: taskNames
+      expression: |
+        has(object.spec) && has(object.spec.tasks) ? 
+        object.spec.tasks.map(task, task.name) : []
+    # Calculate total replicas
+    - name: totalReplicas
+      expression: |
+        has(object.spec) && has(object.spec.tasks) ? 
+        object.spec.tasks.map(task, task.replicas).sum() : 0
+    # Check if tasks have dependencies
+    - name: hasDependencies
+      expression: |
+        has(object.spec) && has(object.spec.tasks) ? 
+        object.spec.tasks.exists(task, has(task.dependsOn) && has(task.dependsOn.name) && size(task.dependsOn.name) > 0) : false
+    # Extract all policy events
+    - name: policyEvents
+      expression: |
+        has(object.spec) && has(object.spec.policies) ? 
+        object.spec.policies.filter(policy, has(policy.event)).map(policy, policy.event) : []
+    # Extract all policy exit codes
+    - name: policyExitCodes
+      expression: |
+        has(object.spec) && has(object.spec.policies) ? 
+        object.spec.policies.filter(policy, has(policy.exitCode)).map(policy, policy.exitCode) : []
+    # Extract volume mount paths
+    - name: volumeMountPaths
+      expression: |
+        has(object.spec) && has(object.spec.volumes) ? 
+        object.spec.volumes.map(volume, volume.mountPath) : []
+    # Valid policy events
+    - name: validEvents
+      expression: |
+        ["*","PodFailed","PodEvicted","PodPending","Unknown","TaskCompleted","JobUpdated","TaskFailed"]
+    # Valid policy actions
+    - name: validActions
+      expression: |
+        ["AbortJob", "RestartJob", "RestartTask", "RestartPod", "TerminateJob", "CompleteJob", "ResumeJob"]
+  validations:
+    # Basic job validations
+    # Validate minAvailable >= 0
+    - expression: |
+        !has(object.spec) || !has(object.spec.minAvailable) || object.spec.minAvailable >= 0
+      message: "job 'minAvailable' must be >= 0"
+      reason: Invalid
+    # Validate maxRetry >= 0
+    - expression: |
+        !has(object.spec) || !has(object.spec.maxRetry) || object.spec.maxRetry >= 0
+      message: "'maxRetry' cannot be less than zero"
+      reason: Invalid
+    # Validate TTLSecondsAfterFinished >= 0
+    - expression: |
+        !has(object.spec) || !has(object.spec.ttlSecondsAfterFinished) || 
+        object.spec.ttlSecondsAfterFinished >= 0
+      message: "'ttlSecondsAfterFinished' cannot be less than zero"
+      reason: Invalid
+    # Validate at least one task is specified
+    - expression: |
+        has(object.spec) && has(object.spec.tasks) && size(object.spec.tasks) > 0
+      message: "No task specified in job spec"
+      reason: Invalid
+    # Validate task names are unique
+    - expression: |
+        !has(object.spec) || !has(object.spec.tasks) || 
+        object.spec.tasks.all(task1, 
+          object.spec.tasks.filter(task2, task2.name == task1.name).size() == 1
+        )
+      message: "duplicated task name found"
+      reason: Invalid
+    # Validate task names are DNS1123 labels using CEL format library (gives precise errors)
+    - expression: |
+        !has(object.spec) || !has(object.spec.tasks) ||
+        object.spec.tasks.all(t, !format.dns1123Label().validate(t.name).hasValue())
+      message: "a lowercase RFC 1123 label must consist of lower case alphanumeric characters"
+      reason: Invalid
+    # Task validations
+    # Validate task replicas >= 0
+    - expression: |
+        !has(object.spec) || !has(object.spec.tasks) ||
+        object.spec.tasks.all(task, !has(task.replicas) || task.replicas >= 0)
+      message: "'replicas' < 0 in task"
+      reason: Invalid
+    # Validate task minAvailable >= 0 when specified
+    - expression: |
+        !has(object.spec) || !has(object.spec.tasks) ||
+        object.spec.tasks.all(task, 
+          !has(task.minAvailable) || task.minAvailable >= 0
+        )
+      message: "'minAvailable' < 0 in task"
+      reason: Invalid
+    # Validate task minAvailable <= replicas when specified
+    - expression: |
+        !has(object.spec) || !has(object.spec.tasks) ||
+        object.spec.tasks.all(task, 
+          !has(task.minAvailable) || !has(task.replicas) || task.minAvailable <= task.replicas
+        )
+      message: "'minAvailable' is greater than 'replicas' in task"
+      reason: Invalid
+    # Validate job minAvailable <= total replicas
+    - expression: |
+        !has(object.spec) || !has(object.spec.minAvailable) ||
+        object.spec.minAvailable <= variables.totalReplicas
+      message: "job 'minAvailable' should not be greater than total replicas in tasks"
+      reason: Invalid
+    # Policy validations
+    # Validate policy events are valid
+    - expression: |
+        !has(object.spec) || !has(object.spec.policies) ||
+        object.spec.policies.all(policy, 
+          !has(policy.event) || policy.event in variables.validEvents
+        )
+      message: "invalid policy event"
+      reason: Invalid
+    # Validate policy actions are valid
+    - expression: |
+        !has(object.spec) || !has(object.spec.policies) ||
+        object.spec.policies.all(policy, 
+          !has(policy.action) || policy.action in variables.validActions
+        )
+      message: "invalid policy action"
+      reason: Invalid
+    # Validate policy has either event or exitCode, not both
+    - expression: |
+        !has(object.spec) || !has(object.spec.policies) ||
+        object.spec.policies.all(policy, 
+          (has(policy.event) && !has(policy.exitCode)) ||
+          (!has(policy.event) && has(policy.exitCode)) ||
+          (!has(policy.event) && !has(policy.exitCode))
+        )
+      message: "must not specify event and exitCode simultaneously"
+      reason: Invalid
+    # Validate policy has either event or exitCode specified
+    - expression: |
+        !has(object.spec) || !has(object.spec.policies) ||
+        object.spec.policies.all(policy, 
+          has(policy.event) || has(policy.exitCode) || (has(policy.events) && size(policy.events) > 0)
+        )
+      message: "either event and exitCode should be specified"
+      reason: Invalid
+    # Validate policy exit code is not zero
+    - expression: |
+        !has(object.spec) || !has(object.spec.policies) ||
+        object.spec.policies.all(policy, 
+          !has(policy.exitCode) || policy.exitCode != 0
+        )
+      message: "0 is not a valid error code"
+      reason: Invalid
+    # Validate no duplicate policy events
+    - expression: |
+        !has(object.spec) || !has(object.spec.policies) ||
+        object.spec.policies.filter(policy, has(policy.event)).all(policy1,
+          object.spec.policies.filter(policy2, has(policy2.event) && policy2.event == policy1.event).size() == 1
+        )
+      message: "duplicate policy event found"
+      reason: Invalid
+    # Validate no duplicate policy exit codes
+    - expression: |
+        !has(object.spec) || !has(object.spec.policies) ||
+        object.spec.policies.filter(policy, has(policy.exitCode)).all(policy1,
+          object.spec.policies.filter(policy2, has(policy2.exitCode) && policy2.exitCode == policy1.exitCode).size() == 1
+        )
+      message: "duplicate exitCode found"
+      reason: Invalid
+    # Validate AnyEvent (*) policy restrictions
+    - expression: |
+        !has(object.spec) || !has(object.spec.policies) ||
+        !("*" in variables.policyEvents) || size(variables.policyEvents) == 1
+      message: "if there's * here, no other policy should be here"
+      reason: Invalid
+    # Volume validations
+    # Validate volume mount paths are not empty
+    - expression: |
+        !has(object.spec) || !has(object.spec.volumes) ||
+        object.spec.volumes.all(volume, volume.mountPath != "")
+      message: "mountPath is required"
+      reason: Invalid
+    # Validate no duplicate volume mount paths
+    - expression: |
+        !has(object.spec) || !has(object.spec.volumes) ||
+        object.spec.volumes.all(volume1,
+          object.spec.volumes.filter(volume2, volume2.mountPath == volume1.mountPath).size() == 1
+        )
+      message: "duplicated mountPath found"
+      reason: Invalid
+    # Validate volume has either VolumeClaimName or VolumeClaim
+    - expression: |
+        !has(object.spec) || !has(object.spec.volumes) ||
+        object.spec.volumes.all(volume, 
+          (has(volume.volumeClaimName) && volume.volumeClaimName != "") ||
+          has(volume.volumeClaim)
+        )
+      message: "either VolumeClaim or VolumeClaimName must be specified"
+      reason: Invalid
+    # Update-specific validations (for UPDATE operations)
+    # Prevent adding or removing tasks
+    - expression: |
+        request.operation != "UPDATE" || 
+        (has(oldObject.spec) && has(oldObject.spec.tasks) && 
+         has(object.spec) && has(object.spec.tasks) &&
+         size(oldObject.spec.tasks) == size(object.spec.tasks))
+      message: "job updates may not add or remove tasks"
+      reason: Invalid
+    # Prevent changing queue name on update
+    - expression: |
+        request.operation != "UPDATE" ||
+        (has(oldObject.spec) && has(oldObject.spec.queue) &&
+         has(object.spec) && has(object.spec.queue) &&
+         oldObject.spec.queue == object.spec.queue)
+      message: "job updates may not change fields other than `minAvailable`, `tasks[*].replicas under spec` and `PriorityClassName`"
+      reason: Invalid
+    # For UPDATE operations, validate minAvailable against new total replicas
+    - expression: |
+        request.operation != "UPDATE" ||
+        !has(object.spec) || !has(object.spec.minAvailable) ||
+        !has(object.spec.tasks) ||
+        object.spec.minAvailable <= object.spec.tasks.map(task, task.replicas).sum()
+      message: "job 'minAvailable' must not be greater than total replicas"
+      reason: Invalid
+    # Validate job name is a valid qualified name using CEL format library
+    - expression: |
+        !has(object.metadata) || !has(object.metadata.name) ||
+        !format.qualifiedName().validate(object.metadata.name).hasValue()
+      message: "job name must be a valid qualified name"
+      messageExpression: |
+        has(object.metadata) && has(object.metadata.name) && format.qualifiedName().validate(object.metadata.name).hasValue() ?
+        'job name errors: ' + format.qualifiedName().validate(object.metadata.name).orValue([]).join('; ') : ''
+      reason: Invalid
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: job-validation-policy-binding
+  labels:
+    volcano.sh/component: job-webhook
+    volcano.sh/migration: vap
+spec:
+  policyName: job-validation-policy
+  validationActions: [Deny]

--- a/installer/helm/chart/volcano/policy/podgroups-mutating.yaml
+++ b/installer/helm/chart/volcano/policy/podgroups-mutating.yaml
@@ -1,0 +1,40 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: volcano-podgroup-mutation-policy
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: Never
+  matchConstraints:
+    resourceRules:
+    - operations: ["CREATE"]
+      apiGroups: ["scheduling.volcano.sh"]
+      apiVersions: ["v1beta1"]
+      resources: ["podgroups"]
+  mutations:
+  # Set queue from namespace annotation if podgroup queue is default
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        object.spec.queue == "default" &&
+        namespaceObject != null &&
+        has(namespaceObject.metadata.annotations) &&
+        "scheduling.volcano.sh/queue-name" in namespaceObject.metadata.annotations ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/queue",
+          value: namespaceObject.metadata.annotations["scheduling.volcano.sh/queue-name"]
+        }] : []
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: volcano-podgroup-mutation-binding
+spec:
+  policyName: volcano-podgroup-mutation-policy
+  matchResources:
+    resourceRules:
+    - operations: ["CREATE"]
+      apiGroups: ["scheduling.volcano.sh"]
+      apiVersions: ["v1beta1"]
+      resources: ["podgroups"]

--- a/installer/helm/chart/volcano/policy/podgroups-validating.yaml
+++ b/installer/helm/chart/volcano/policy/podgroups-validating.yaml
@@ -1,0 +1,42 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: podgroup-validation-policy
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - operations: ["CREATE"]
+        apiGroups: ["scheduling.volcano.sh"]
+        apiVersions: ["v1beta1"]
+        resources: ["podgroups"]
+  variables:
+    # Extract the queue name if specified
+    - name: queueName
+      expression: |
+        has(object.spec) && has(object.spec.queue) ? object.spec.queue : ""
+  validations:
+    # Note: Original webhook only validates queue state, but ValidatingAdmissionPolicy
+    # cannot query cluster state to check if queue exists and is open.
+    # This validation is a placeholder - the actual queue state checking
+    # must be done by the remaining webhook or controller logic.
+    - expression: "true"
+      message: "PodGroup validation passed - queue validation handled elsewhere"
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: podgroup-validation-policy-binding
+  labels:
+    volcano.sh/component: podgroup-webhook
+    volcano.sh/migration: vap
+spec:
+  policyName: podgroup-validation-policy
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+      - operations: ["CREATE"]
+        apiGroups: ["scheduling.volcano.sh"]
+        apiVersions: ["v1beta1"]
+        resources: ["podgroups"]

--- a/installer/helm/chart/volcano/policy/pods-mutating.yaml
+++ b/installer/helm/chart/volcano/policy/pods-mutating.yaml
@@ -1,0 +1,129 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: volcano-pod-mutation-policy
+spec:
+  # NOTE: This MutatingAdmissionPolicy provides a PARTIAL replacement for the webhook
+  # implementation. It contains HARDCODED logic for specific resource groups and namespaces
+  # and CANNOT handle dynamic configuration like the webhook implementation.
+  #
+  # IMPLEMENTED:
+  # - Scheduler name setting for 'default' resource group and 'volcano-system' namespace
+  # - Basic nodeSelector and tolerations for 'default' resource group
+  # - Fixed node-group labels and tolerations
+  #
+  # NOT IMPLEMENTED:
+  # - Dynamic configuration reading from config files
+  # - Configurable resource groups beyond 'default'
+  # - Flexible namespace handling beyond 'volcano-system'
+  # - Custom node selectors and tolerations per configuration
+  #
+  # For complete functionality with configurable resource groups and namespaces,
+  # the existing webhook must remain active alongside this policy.
+
+  failurePolicy: Fail
+  reinvocationPolicy: Never
+  matchConstraints:
+    resourceRules:
+    - operations: ["CREATE"]
+      apiGroups: [""]
+      apiVersions: ["v1"] 
+      resources: ["pods"]
+  mutations:
+  # Patch scheduler name when pod has volcano resource group annotation
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        has(object.metadata.annotations) &&
+        'volcano.sh/resource-group' in object.metadata.annotations &&
+        object.metadata.annotations['volcano.sh/resource-group'] == 'default' ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/schedulerName",
+          value: "volcano"
+        }] : []
+
+  # Add nodeSelector field if it doesn't exist for resource group matching
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        has(object.metadata.annotations) &&
+        'volcano.sh/resource-group' in object.metadata.annotations &&
+        object.metadata.annotations['volcano.sh/resource-group'] == 'default' &&
+        !has(object.spec.nodeSelector) ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/nodeSelector",
+          value: {}
+        }] : []
+
+  # Add specific nodeSelector label
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        has(object.metadata.annotations) &&
+        'volcano.sh/resource-group' in object.metadata.annotations &&
+        object.metadata.annotations['volcano.sh/resource-group'] == 'default' ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/nodeSelector/" + jsonpatch.escapeKey("volcano.sh/node-group"),
+          value: "compute"
+        }] : []
+
+  # Add tolerations field if it doesn't exist for resource group matching
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        has(object.metadata.annotations) &&
+        'volcano.sh/resource-group' in object.metadata.annotations &&
+        object.metadata.annotations['volcano.sh/resource-group'] == 'default' &&
+        !has(object.spec.tolerations) ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/tolerations",
+          value: []
+        }] : []
+
+  # Add toleration entry  
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        has(object.metadata.annotations) &&
+        'volcano.sh/resource-group' in object.metadata.annotations &&
+        object.metadata.annotations['volcano.sh/resource-group'] == 'default' ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/tolerations/-",
+          value: {
+            "key": "volcano.sh/node-group",
+            "operator": "Equal",
+            "value": "compute", 
+            "effect": "NoSchedule"
+          }
+        }] : []
+
+  # Handle namespace-based resource group matching (example for 'volcano-system' namespace)
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        object.metadata.namespace == 'volcano-system' &&
+        (!has(object.metadata.annotations) || 
+         !('volcano.sh/resource-group' in object.metadata.annotations)) ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/schedulerName", 
+          value: "volcano"
+        }] : []
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: volcano-pod-mutation-binding
+spec:
+  policyName: volcano-pod-mutation-policy
+  matchResources:
+    resourceRules:
+    - operations: ["CREATE"]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]

--- a/installer/helm/chart/volcano/policy/pods-validating.yaml
+++ b/installer/helm/chart/volcano/policy/pods-validating.yaml
@@ -1,0 +1,65 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: pod-validation-policy
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+  variables:
+    - name: volcanoScheduler
+      expression: |
+        has(object.spec.schedulerName) && ["volcano"].exists(s, s == object.spec.schedulerName)
+  validations:
+    # not allow configure multiple annotations at same time
+    - expression: |
+        !variables.volcanoScheduler || !has(object.metadata.annotations) || !(
+          ("volcano.sh/jdb-min-available" in object.metadata.annotations) &&
+          ("volcano.sh/jdb-max-unavailable" in object.metadata.annotations)
+        )
+      message: "not allow configure multiple annotations at same time"
+      reason: Invalid
+    # not allow negative values for jdb-min-available
+    - expression: |
+        !variables.volcanoScheduler || !has(object.metadata.annotations) || !("volcano.sh/jdb-min-available" in object.metadata.annotations) ||
+        (
+          object.metadata.annotations["volcano.sh/jdb-min-available"].matches('^[0-9]+$') &&
+          int(object.metadata.annotations["volcano.sh/jdb-min-available"]) > 0
+        ) ||
+        (
+          object.metadata.annotations["volcano.sh/jdb-min-available"].matches('^[0-9]+%$') &&
+          int(object.metadata.annotations["volcano.sh/jdb-min-available"].replace('%', '')) > 0 &&
+          int(object.metadata.annotations["volcano.sh/jdb-min-available"].replace('%', '')) < 100
+        )
+      message: "jdb-min-available must be a positive integer or a valid percentage which between 1% ~ 99%"
+      reason: Invalid
+    # not allow negative values for jdb-max-unavailable
+    - expression: |
+        !variables.volcanoScheduler || !has(object.metadata.annotations) || !("volcano.sh/jdb-max-unavailable" in object.metadata.annotations) ||
+        (
+          object.metadata.annotations["volcano.sh/jdb-max-unavailable"].matches('^[0-9]+$') &&
+          int(object.metadata.annotations["volcano.sh/jdb-max-unavailable"]) > 0
+        ) ||
+        (
+          object.metadata.annotations["volcano.sh/jdb-max-unavailable"].matches('^[0-9]+%$') &&
+          int(object.metadata.annotations["volcano.sh/jdb-max-unavailable"].replace('%', '')) > 0 &&
+          int(object.metadata.annotations["volcano.sh/jdb-max-unavailable"].replace('%', '')) < 100
+        )
+      message: "jdb-max-unavailable must be a positive integer or a valid percentage which between 1% ~ 99%"
+      reason: Invalid
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: pod-validation-policy-binding
+  labels:
+    volcano.sh/component: pod-webhook
+    volcano.sh/migration: vap
+spec:
+  policyName: pod-validation-policy
+  validationActions: [Deny]

--- a/installer/helm/chart/volcano/policy/queues-mutating.yaml
+++ b/installer/helm/chart/volcano/policy/queues-mutating.yaml
@@ -1,0 +1,71 @@
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: volcano-queue-mutation-policy
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: Never
+  matchConstraints:
+    resourceRules:
+    - operations: ["CREATE"]
+      apiGroups: ["scheduling.volcano.sh"]
+      apiVersions: ["v1beta1"]
+      resources: ["queues"]
+  mutations:
+  # Add root prefix to hierarchy annotation if hierarchy is specified but doesn't start with "root"
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        has(object.metadata.annotations) &&
+        "volcano.sh/hierarchy" in object.metadata.annotations &&
+        "volcano.sh/hierarchy-weights" in object.metadata.annotations &&
+        object.metadata.annotations["volcano.sh/hierarchy"] != "" &&
+        object.metadata.annotations["volcano.sh/hierarchy-weights"] != "" &&
+        !object.metadata.annotations["volcano.sh/hierarchy"].startsWith("root") ?
+        [
+          JSONPatch{
+            op: "add",
+            path: "/metadata/annotations/" + jsonpatch.escapeKey("volcano.sh/hierarchy"),
+            value: "root/" + object.metadata.annotations["volcano.sh/hierarchy"]
+          },
+          JSONPatch{
+            op: "add",
+            path: "/metadata/annotations/" + jsonpatch.escapeKey("volcano.sh/hierarchy-weights"),
+            value: "1/" + object.metadata.annotations["volcano.sh/hierarchy-weights"]
+          }
+        ] : []
+
+  # Set default reclaimable to true
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        !has(object.spec.reclaimable) ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/reclaimable",
+          value: true
+        }] : []
+
+  # Set default weight to 1 if weight is 0 or not specified
+  - patchType: JSONPatch
+    jsonPatch:
+      expression: |
+        (!has(object.spec.weight) || object.spec.weight == 0) ?
+        [JSONPatch{
+          op: "add",
+          path: "/spec/weight", 
+          value: 1
+        }] : []
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: volcano-queue-mutation-binding
+spec:
+  policyName: volcano-queue-mutation-policy
+  matchResources:
+    resourceRules:
+    - operations: ["CREATE"]
+      apiGroups: ["scheduling.volcano.sh"]
+      apiVersions: ["v1beta1"] 
+      resources: ["queues"]

--- a/installer/helm/chart/volcano/policy/queues-validating.yaml
+++ b/installer/helm/chart/volcano/policy/queues-validating.yaml
@@ -1,0 +1,136 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: queue-validation-policy
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - operations: ["CREATE", "UPDATE", "DELETE"]
+        apiGroups: ["scheduling.volcano.sh"]
+        apiVersions: ["v1beta1"]
+        resources: ["queues"]
+  variables:
+    # Extract hierarchy annotation if present
+    - name: hierarchyPath
+      expression: |
+        has(object.metadata) && has(object.metadata.annotations) && "volcano.sh/hierarchy" in object.metadata.annotations ? 
+        object.metadata.annotations["volcano.sh/hierarchy"] : ""
+    # Extract hierarchy weights annotation if present
+    - name: hierarchyWeights
+      expression: |
+        has(object.metadata) && has(object.metadata.annotations) && "volcano.sh/hierarchy-weights" in object.metadata.annotations ?
+        object.metadata.annotations["volcano.sh/hierarchy-weights"] : ""
+    # Split hierarchy path by "/"
+    - name: hierarchyPaths
+      expression: |
+        variables.hierarchyPath != "" ? variables.hierarchyPath.split('/') : []
+    # Split hierarchy weights by "/"
+    - name: hierarchyWeightsList
+      expression: |
+        variables.hierarchyWeights != "" ? variables.hierarchyWeights.split('/') : []
+  validations:
+    # Validate queue state - only allow "Open" or "Closed" or empty
+    - expression: |
+        !has(object.status) || !has(object.status.state) || object.status.state == "" ||
+        object.status.state == "Open" || object.status.state == "Closed"
+      message: "queue state must be in [Open, Closed]"
+      reason: Invalid
+        # Basic resource validation - ensure resource values are non-empty when defined
+    - expression: |
+        !has(object.spec) || !has(object.spec.capability) || 
+        object.spec.capability.all(k, object.spec.capability[k] != "")
+      message: "capability resource values must not be empty"
+      reason: Invalid
+    - expression: |
+        !has(object.spec) || !has(object.spec.deserved) || 
+        object.spec.deserved.all(k, object.spec.deserved[k] != "")
+      message: "deserved resource values must not be empty"
+      reason: Invalid
+    - expression: |
+        !has(object.spec) || !has(object.spec.guarantee) || !has(object.spec.guarantee.resource) || 
+        object.spec.guarantee.resource.all(k, object.spec.guarantee.resource[k] != "")
+      message: "guarantee resource values must not be empty"
+      reason: Invalid
+    # Resource comparison validation using k8s quantity library
+    # Validate deserved <= capability (deserved should less equal than capability)
+    - expression: |
+        !has(object.spec) || !has(object.spec.capability) || !has(object.spec.deserved) ||
+        size(object.spec.capability) == 0 || size(object.spec.deserved) == 0 ||
+        object.spec.capability.all(resourceName,
+          !(resourceName in object.spec.deserved) ||
+          quantity(object.spec.capability[resourceName]).compareTo(quantity(object.spec.deserved[resourceName])) >= 0
+        ) &&
+        object.spec.deserved.all(resourceName,
+          resourceName in object.spec.capability &&
+          quantity(object.spec.deserved[resourceName]).compareTo(quantity(object.spec.capability[resourceName])) <= 0
+        )
+      message: "deserved should less equal than capability"
+      reason: Invalid
+    # Validate guarantee <= capability (guarantee should less equal than capability)
+    - expression: |
+        !has(object.spec) || !has(object.spec.capability) || !has(object.spec.guarantee) ||
+        !has(object.spec.guarantee.resource) || size(object.spec.capability) == 0 ||
+        size(object.spec.guarantee.resource) == 0 ||
+        object.spec.capability.all(resourceName,
+          !(resourceName in object.spec.guarantee.resource) ||
+          quantity(object.spec.capability[resourceName]).compareTo(quantity(object.spec.guarantee.resource[resourceName])) >= 0
+        ) &&
+        object.spec.guarantee.resource.all(resourceName,
+          resourceName in object.spec.capability &&
+          quantity(object.spec.guarantee.resource[resourceName]).compareTo(quantity(object.spec.capability[resourceName])) <= 0
+        )
+      message: "guarantee should less equal than capability"
+      reason: Invalid
+    # Validate guarantee <= deserved (guarantee should less equal than deserved)
+    - expression: |
+        !has(object.spec) || !has(object.spec.deserved) || !has(object.spec.guarantee) ||
+        !has(object.spec.guarantee.resource) || size(object.spec.deserved) == 0 ||
+        size(object.spec.guarantee.resource) == 0 ||
+        object.spec.deserved.all(resourceName,
+          !(resourceName in object.spec.guarantee.resource) ||
+          quantity(object.spec.deserved[resourceName]).compareTo(quantity(object.spec.guarantee.resource[resourceName])) >= 0
+        ) &&
+        object.spec.guarantee.resource.all(resourceName,
+          resourceName in object.spec.deserved &&
+          quantity(object.spec.guarantee.resource[resourceName]).compareTo(quantity(object.spec.deserved[resourceName])) <= 0
+        )
+      message: "guarantee should less equal than deserved"
+      reason: Invalid
+    # Validate hierarchical attributes - path and weights length must match
+    - expression: |
+        (variables.hierarchyPath == "" && variables.hierarchyWeights == "") ||
+        (variables.hierarchyPath != "" && variables.hierarchyWeights != "" && 
+         size(variables.hierarchyPaths) == size(variables.hierarchyWeightsList))
+      message: "volcano.sh/hierarchy must have the same length with volcano.sh/hierarchy-weights"
+      reason: Invalid
+    # Validate hierarchical weights - all must be positive numbers
+    - expression: |
+        variables.hierarchyWeights == "" ||
+        variables.hierarchyWeightsList.all(weight, 
+          weight.matches('^[0-9]+(\\.[0-9]+)?$') && double(weight) > 0
+        )
+      message: "weights in volcano.sh/hierarchy-weights must be larger than 0"
+      reason: Invalid
+    # Prevent deletion of default queue
+    - expression: |
+        request.operation != "DELETE" || oldObject.metadata.name != "default"
+      message: "`default` queue can not be deleted"
+      reason: Invalid
+    # Prevent deletion of root queue
+    - expression: |
+        request.operation != "DELETE" || oldObject.metadata.name != "root"
+      message: "`root` queue can not be deleted"
+      reason: Invalid
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: queue-validation-policy-binding
+  labels:
+    volcano.sh/component: queue-webhook
+    volcano.sh/migration: vap
+spec:
+  policyName: queue-validation-policy
+  validationActions: [Deny]

--- a/installer/helm/chart/volcano/templates/mutating_admission_policy.yaml
+++ b/installer/helm/chart/volcano/templates/mutating_admission_policy.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.custom.map_enable }}
+{{ .Files.Get "policy/jobs-mutating.yaml" }}
+---
+{{ .Files.Get "policy/queues-mutating.yaml" }}
+---
+{{ .Files.Get "policy/podgroups-mutating.yaml" }}
+---
+{{ .Files.Get "policy/pods-mutating.yaml" }}
+{{- end }}

--- a/installer/helm/chart/volcano/templates/validating_admission_policy.yaml
+++ b/installer/helm/chart/volcano/templates/validating_admission_policy.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.custom.vap_enable }}
+{{ .Files.Get "policy/jobs-validating.yaml" }}
+---
+{{ .Files.Get "policy/queues-validating.yaml" }}
+---
+{{ .Files.Get "policy/podgroups-validating.yaml" }}
+---
+{{ .Files.Get "policy/pods-validating.yaml" }}
+---
+{{ .Files.Get "policy/hypernodes-validating.yaml" }}
+---
+{{ .Files.Get "policy/jobflows-validating.yaml" }}
+{{- end }}

--- a/installer/helm/chart/volcano/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano/templates/webhooks.yaml
@@ -469,7 +469,6 @@ webhooks:
     timeoutSeconds: 10
 {{- end }}
 {{- if .Values.custom.enabled_admissions | regexMatch "/cronjobs/validate" }} 
-{{- end }}
 ---  
 apiVersion: admissionregistration.k8s.io/v1  
 kind: ValidatingWebhookConfiguration  
@@ -515,4 +514,5 @@ webhooks:
         scope: '*'  
     sideEffects: NoneOnDryRun  
     timeoutSeconds: 10  
+{{- end }}
 {{- end }}

--- a/installer/helm/chart/volcano/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano/templates/webhooks.yaml
@@ -468,51 +468,51 @@ webhooks:
     sideEffects: None
     timeoutSeconds: 10
 {{- end }}
-{{- if .Values.custom.enabled_admissions | regexMatch "/cronjobs/validate" }}
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: volcano-admission-service-cronjobs-validate
-  {{- if .Values.custom.common_labels }}
-  labels:
-    {{- toYaml .Values.custom.common_labels | nindent 4 }}
-  {{- end }}
-webhooks:
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: {{ .Release.Name }}-admission-service
-        namespace: {{ .Release.Namespace }}
-        path: /cronjobs/validate
-        port: 443
-    failurePolicy: Fail
-    matchPolicy: Equivalent
-    name: validatecronjob.volcano.sh
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - {{ .Release.Namespace }}
-            - kube-system
-{{- if .Values.custom.webhooks_namespace_selector_expressions }}
-        {{- toYaml .Values.custom.webhooks_namespace_selector_expressions | nindent 8 }}
+{{- if .Values.custom.enabled_admissions | regexMatch "/cronjobs/validate" }} 
 {{- end }}
-    objectSelector: {}
-    rules:
-      - apiGroups:
-          - batch.volcano.sh
-        apiVersions:
-          - v1alpha1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - cronjobs
-        scope: '*'
-    sideEffects: NoneOnDryRun
-    timeoutSeconds: 10
-{{- end }}
+---  
+apiVersion: admissionregistration.k8s.io/v1  
+kind: ValidatingWebhookConfiguration  
+metadata:  
+  name: volcano-admission-service-cronjobs-validate  
+  {{- if .Values.custom.common_labels }}  
+  labels:  
+    {{- toYaml .Values.custom.common_labels | nindent 4 }}  
+  {{- end }}  
+webhooks:  
+  - admissionReviewVersions:  
+      - v1  
+    clientConfig:  
+      service:  
+        name: {{ .Release.Name }}-admission-service  
+        namespace: {{ .Release.Namespace }}  
+        path: /cronjobs/validate  
+        port: 443  
+    failurePolicy: Fail  
+    matchPolicy: Equivalent  
+    name: validatecronjob.volcano.sh  
+    namespaceSelector:  
+      matchExpressions:  
+        - key: kubernetes.io/metadata.name  
+          operator: NotIn  
+          values:  
+            - {{ .Release.Namespace }}  
+            - kube-system  
+{{- if .Values.custom.webhooks_namespace_selector_expressions }}  
+        {{- toYaml .Values.custom.webhooks_namespace_selector_expressions | nindent 8 }}  
+{{- end }}  
+    objectSelector: {}  
+    rules:  
+      - apiGroups:  
+          - batch.volcano.sh  
+        apiVersions:  
+          - v1alpha1  
+        operations:  
+          - CREATE  
+          - UPDATE  
+        resources:  
+          - cronjobs  
+        scope: '*'  
+    sideEffects: NoneOnDryRun  
+    timeoutSeconds: 10  
 {{- end }}

--- a/installer/helm/chart/volcano/templates/webhooks.yaml
+++ b/installer/helm/chart/volcano/templates/webhooks.yaml
@@ -468,51 +468,51 @@ webhooks:
     sideEffects: None
     timeoutSeconds: 10
 {{- end }}
-{{- if .Values.custom.enabled_admissions | regexMatch "/cronjobs/validate" }} 
+{{- if .Values.custom.enabled_admissions | regexMatch "/cronjobs/validate" }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: volcano-admission-service-cronjobs-validate
+  {{- if .Values.custom.common_labels }}
+  labels:
+    {{- toYaml .Values.custom.common_labels | nindent 4 }}
+  {{- end }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ .Release.Name }}-admission-service
+        namespace: {{ .Release.Namespace }}
+        path: /cronjobs/validate
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: validatecronjob.volcano.sh
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - {{ .Release.Namespace }}
+            - kube-system
+{{- if .Values.custom.webhooks_namespace_selector_expressions }}
+        {{- toYaml .Values.custom.webhooks_namespace_selector_expressions | nindent 8 }}
 {{- end }}
----  
-apiVersion: admissionregistration.k8s.io/v1  
-kind: ValidatingWebhookConfiguration  
-metadata:  
-  name: volcano-admission-service-cronjobs-validate  
-  {{- if .Values.custom.common_labels }}  
-  labels:  
-    {{- toYaml .Values.custom.common_labels | nindent 4 }}  
-  {{- end }}  
-webhooks:  
-  - admissionReviewVersions:  
-      - v1  
-    clientConfig:  
-      service:  
-        name: {{ .Release.Name }}-admission-service  
-        namespace: {{ .Release.Namespace }}  
-        path: /cronjobs/validate  
-        port: 443  
-    failurePolicy: Fail  
-    matchPolicy: Equivalent  
-    name: validatecronjob.volcano.sh  
-    namespaceSelector:  
-      matchExpressions:  
-        - key: kubernetes.io/metadata.name  
-          operator: NotIn  
-          values:  
-            - {{ .Release.Namespace }}  
-            - kube-system  
-{{- if .Values.custom.webhooks_namespace_selector_expressions }}  
-        {{- toYaml .Values.custom.webhooks_namespace_selector_expressions | nindent 8 }}  
-{{- end }}  
-    objectSelector: {}  
-    rules:  
-      - apiGroups:  
-          - batch.volcano.sh  
-        apiVersions:  
-          - v1alpha1  
-        operations:  
-          - CREATE  
-          - UPDATE  
-        resources:  
-          - cronjobs  
-        scope: '*'  
-    sideEffects: NoneOnDryRun  
-    timeoutSeconds: 10  
+    objectSelector: {}
+    rules:
+      - apiGroups:
+          - batch.volcano.sh
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cronjobs
+        scope: '*'
+    sideEffects: NoneOnDryRun
+    timeoutSeconds: 10
+{{- end }}
 {{- end }}

--- a/installer/helm/chart/volcano/values.yaml
+++ b/installer/helm/chart/volcano/values.yaml
@@ -25,6 +25,10 @@ custom:
   scheduler_plugins_dir: ""
   scheduler_name: ~
   leader_elect_enable: false
+  # ValidatingAdmissionPolicy settings (auto-enabled for K8s >= 1.30)
+  vap_enable: false
+  # MutatingAdmissionPolicy settings (default disabled)
+  map_enable: false
   controller_kube_api_qps: 50
   controller_kube_api_burst: 100
   controller_worker_threads: 3

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -9810,42 +9810,42 @@ webhooks:
     timeoutSeconds: 10
 ---
 # Source: volcano/templates/webhooks.yaml
-apiVersion: admissionregistration.k8s.io/v1  
-kind: ValidatingWebhookConfiguration  
-metadata:  
-  name: volcano-admission-service-cronjobs-validate  
-webhooks:  
-  - admissionReviewVersions:  
-      - v1  
-    clientConfig:  
-      service:  
-        name: volcano-admission-service  
-        namespace: volcano-system  
-        path: /cronjobs/validate  
-        port: 443  
-    failurePolicy: Fail  
-    matchPolicy: Equivalent  
-    name: validatecronjob.volcano.sh  
-    namespaceSelector:  
-      matchExpressions:  
-        - key: kubernetes.io/metadata.name  
-          operator: NotIn  
-          values:  
-            - volcano-system  
-            - kube-system  
-    objectSelector: {}  
-    rules:  
-      - apiGroups:  
-          - batch.volcano.sh  
-        apiVersions:  
-          - v1alpha1  
-        operations:  
-          - CREATE  
-          - UPDATE  
-        resources:  
-          - cronjobs  
-        scope: '*'  
-    sideEffects: NoneOnDryRun  
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: volcano-admission-service-cronjobs-validate
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: volcano-admission-service
+        namespace: volcano-system
+        path: /cronjobs/validate
+        port: 443
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: validatecronjob.volcano.sh
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - volcano-system
+            - kube-system
+    objectSelector: {}
+    rules:
+      - apiGroups:
+          - batch.volcano.sh
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - cronjobs
+        scope: '*'
+    sideEffects: NoneOnDryRun
     timeoutSeconds: 10
 ---
 # Source: jobflow/templates/flow_v1alpha1_jobflows.yaml

--- a/installer/volcano-development.yaml
+++ b/installer/volcano-development.yaml
@@ -9810,42 +9810,42 @@ webhooks:
     timeoutSeconds: 10
 ---
 # Source: volcano/templates/webhooks.yaml
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: volcano-admission-service-cronjobs-validate
-webhooks:
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: volcano-admission-service
-        namespace: volcano-system
-        path: /cronjobs/validate
-        port: 443
-    failurePolicy: Fail
-    matchPolicy: Equivalent
-    name: validatecronjob.volcano.sh
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - volcano-system
-            - kube-system
-    objectSelector: {}
-    rules:
-      - apiGroups:
-          - batch.volcano.sh
-        apiVersions:
-          - v1alpha1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - cronjobs
-        scope: '*'
-    sideEffects: NoneOnDryRun
+apiVersion: admissionregistration.k8s.io/v1  
+kind: ValidatingWebhookConfiguration  
+metadata:  
+  name: volcano-admission-service-cronjobs-validate  
+webhooks:  
+  - admissionReviewVersions:  
+      - v1  
+    clientConfig:  
+      service:  
+        name: volcano-admission-service  
+        namespace: volcano-system  
+        path: /cronjobs/validate  
+        port: 443  
+    failurePolicy: Fail  
+    matchPolicy: Equivalent  
+    name: validatecronjob.volcano.sh  
+    namespaceSelector:  
+      matchExpressions:  
+        - key: kubernetes.io/metadata.name  
+          operator: NotIn  
+          values:  
+            - volcano-system  
+            - kube-system  
+    objectSelector: {}  
+    rules:  
+      - apiGroups:  
+          - batch.volcano.sh  
+        apiVersions:  
+          - v1alpha1  
+        operations:  
+          - CREATE  
+          - UPDATE  
+        resources:  
+          - cronjobs  
+        scope: '*'  
+    sideEffects: NoneOnDryRun  
     timeoutSeconds: 10
 ---
 # Source: jobflow/templates/flow_v1alpha1_jobflows.yaml

--- a/test/e2e/admission/e2e_test.go
+++ b/test/e2e/admission/e2e_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package admission
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Volcano Admission Test Suite")
+}

--- a/test/e2e/admission/hypernode_validation_test.go
+++ b/test/e2e/admission/hypernode_validation_test.go
@@ -1,0 +1,386 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hypernodev1alpha1 "volcano.sh/apis/pkg/apis/topology/v1alpha1"
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("HyperNode Validating E2E Test", func() {
+
+	ginkgo.It("Should allow HyperNode creation with valid exactMatch selector", func() {
+		hyperNodeName := "valid-exact-match-hypernode"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier: 1,
+				Members: []hypernodev1alpha1.MemberSpec{
+					{
+						Type: hypernodev1alpha1.MemberTypeNode,
+						Selector: hypernodev1alpha1.MemberSelector{
+							ExactMatch: &hypernodev1alpha1.ExactMatch{
+								Name: "node-1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Delete(context.TODO(), hyperNodeName, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow HyperNode creation with valid regexMatch selector", func() {
+		hyperNodeName := "valid-regex-match-hypernode"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier: 1,
+				Members: []hypernodev1alpha1.MemberSpec{
+					{
+						Type: hypernodev1alpha1.MemberTypeNode,
+						Selector: hypernodev1alpha1.MemberSelector{
+							RegexMatch: &hypernodev1alpha1.RegexMatch{
+								Pattern: "node-[0-9]+",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Delete(context.TODO(), hyperNodeName, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow HyperNode creation with valid labelMatch selector", func() {
+		hyperNodeName := "valid-label-match-hypernode"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier: 1,
+				Members: []hypernodev1alpha1.MemberSpec{
+					{
+						Type: hypernodev1alpha1.MemberTypeNode,
+						Selector: hypernodev1alpha1.MemberSelector{
+							LabelMatch: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"topology-rack": "rack1",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Delete(context.TODO(), hyperNodeName, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject HyperNode creation with empty exactMatch name", func() {
+		hyperNodeName := "invalid-empty-exact-match"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier: 1,
+				Members: []hypernodev1alpha1.MemberSpec{
+					{
+						Type: hypernodev1alpha1.MemberTypeNode,
+						Selector: hypernodev1alpha1.MemberSelector{
+							ExactMatch: &hypernodev1alpha1.ExactMatch{
+								Name: "",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("member exactMatch name is required"))
+	})
+
+	ginkgo.It("Should reject HyperNode creation with empty regexMatch pattern", func() {
+		hyperNodeName := "invalid-empty-regex-pattern"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier: 1,
+				Members: []hypernodev1alpha1.MemberSpec{
+					{
+						Type: hypernodev1alpha1.MemberTypeNode,
+						Selector: hypernodev1alpha1.MemberSelector{
+							RegexMatch: &hypernodev1alpha1.RegexMatch{
+								Pattern: "",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("member regexMatch pattern is required"))
+	})
+
+	ginkgo.It("Should reject HyperNode creation with invalid regex pattern", func() {
+		hyperNodeName := "invalid-regex-pattern"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier: 1,
+				Members: []hypernodev1alpha1.MemberSpec{
+					{
+						Type: hypernodev1alpha1.MemberTypeNode,
+						Selector: hypernodev1alpha1.MemberSelector{
+							RegexMatch: &hypernodev1alpha1.RegexMatch{
+								Pattern: "a(b",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("member regexMatch pattern is invalid"))
+	})
+
+	ginkgo.It("Should reject HyperNode creation with no members", func() {
+		hyperNodeName := "invalid-no-members"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier:    1,
+				Members: []hypernodev1alpha1.MemberSpec{},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("member must have at least one member"))
+	})
+
+	ginkgo.It("Should reject HyperNode creation with invalid exactMatch name (invalid DNS name)", func() {
+		hyperNodeName := "invalid-dns-name"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier: 1,
+				Members: []hypernodev1alpha1.MemberSpec{
+					{
+						Type: hypernodev1alpha1.MemberTypeNode,
+						Selector: hypernodev1alpha1.MemberSelector{
+							ExactMatch: &hypernodev1alpha1.ExactMatch{
+								Name: "Node_with_invalid@characters",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("member exactMatch validate failed"))
+	})
+
+	ginkgo.It("Should allow HyperNode update with valid changes", func() {
+		hyperNodeName := "update-test-hypernode"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// Create initial HyperNode
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier: 1,
+				Members: []hypernodev1alpha1.MemberSpec{
+					{
+						Type: hypernodev1alpha1.MemberTypeNode,
+						Selector: hypernodev1alpha1.MemberSelector{
+							ExactMatch: &hypernodev1alpha1.ExactMatch{
+								Name: "node-1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Retry update with fresh object on conflict
+		var updateErr error
+		for retryCount := 0; retryCount < 5; retryCount++ {
+			// Fetch the latest version before updating
+			latestHyperNode, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Get(context.TODO(), hyperNodeName, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Update HyperNode with valid changes
+			latestHyperNode.Spec.Members = []hypernodev1alpha1.MemberSpec{
+				{
+					Type: hypernodev1alpha1.MemberTypeNode,
+					Selector: hypernodev1alpha1.MemberSelector{
+						RegexMatch: &hypernodev1alpha1.RegexMatch{
+							Pattern: "node-[1-5]",
+						},
+					},
+				},
+			}
+
+			_, updateErr = testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Update(context.TODO(), latestHyperNode, metav1.UpdateOptions{})
+			if updateErr == nil {
+				break // Success
+			}
+			// Only retry on conflict errors
+			if !errors.IsConflict(updateErr) {
+				break
+			}
+		}
+		gomega.Expect(updateErr).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Delete(context.TODO(), hyperNodeName, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject HyperNode update with invalid changes", func() {
+		hyperNodeName := "update-invalid-test-hypernode"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// Create initial HyperNode
+		hyperNode := &hypernodev1alpha1.HyperNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: hyperNodeName,
+			},
+			Spec: hypernodev1alpha1.HyperNodeSpec{
+				Tier: 1,
+				Members: []hypernodev1alpha1.MemberSpec{
+					{
+						Type: hypernodev1alpha1.MemberTypeNode,
+						Selector: hypernodev1alpha1.MemberSelector{
+							ExactMatch: &hypernodev1alpha1.ExactMatch{
+								Name: "node-1",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Create(context.TODO(), hyperNode, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Retry update with fresh object on conflict, but expect validation error
+		var updateErr error
+		for retryCount := 0; retryCount < 5; retryCount++ {
+			// Fetch the latest version before updating
+			latestHyperNode, err := testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Get(context.TODO(), hyperNodeName, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Update HyperNode with invalid changes (empty members)
+			latestHyperNode.Spec.Members = []hypernodev1alpha1.MemberSpec{}
+
+			_, updateErr = testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Update(context.TODO(), latestHyperNode, metav1.UpdateOptions{})
+			// If we get a conflict, retry with fresh object
+			if errors.IsConflict(updateErr) {
+				continue
+			}
+			// For any other error (including validation errors), break and check
+			break
+		}
+
+		// We expect an error containing our validation message
+		gomega.Expect(updateErr).To(gomega.HaveOccurred())
+		gomega.Expect(updateErr.Error()).To(gomega.ContainSubstring("member must have at least one member"))
+
+		// Cleanup
+		err = testCtx.Vcclient.TopologyV1alpha1().HyperNodes().Delete(context.TODO(), hyperNodeName, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/test/e2e/admission/job_mutate_test.go
+++ b/test/e2e/admission/job_mutate_test.go
@@ -1,0 +1,446 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+const (
+	defaultQueue = "default"
+	// task-level mutations are no longer handled by MutatingAdmissionPolicy
+)
+
+var _ = ginkgo.Describe("Job Mutating E2E Test", func() {
+
+	ginkgo.It("Should add default queue when not specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-queue-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				// Queue not specified
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "task-1",
+						Replicas: 1,
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdJob.Spec.Queue).To(gomega.Equal(defaultQueue))
+	})
+
+	ginkgo.It("Should add default scheduler name when not specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-scheduler-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				// SchedulerName not specified
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "task-1",
+						Replicas: 1,
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdJob.Spec.SchedulerName).NotTo(gomega.BeEmpty())
+	})
+
+	ginkgo.It("Should add default maxRetry when not specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-max-retry-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				// MaxRetry not specified (defaults to 0)
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "task-1",
+						Replicas: 1,
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdJob.Spec.MaxRetry).To(gomega.Equal(int32(3)))
+	})
+
+	ginkgo.It("Should calculate and set default minAvailable when not specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-min-available-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				// MinAvailable not specified (defaults to 0)
+				Queue: "default",
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "task-1",
+						Replicas: 2,
+						Template: createPodTemplateForMutation(),
+					},
+					{
+						Name:     "task-2",
+						Replicas: 3,
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Should calculate minAvailable as sum of all task replicas (2 + 3 = 5)
+		gomega.Expect(createdJob.Spec.MinAvailable).To(gomega.Equal(int32(5)))
+	})
+
+	ginkgo.It("Should calculate minAvailable considering task-level minAvailable when specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		taskMinAvailable := int32(1)
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task-min-available-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				// MinAvailable not specified (defaults to 0)
+				Queue: "default",
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:         "task-1",
+						Replicas:     2,
+						MinAvailable: &taskMinAvailable, // Specified as 1
+						Template:     createPodTemplateForMutation(),
+					},
+					{
+						Name:     "task-2",
+						Replicas: 3,
+						// MinAvailable not specified, should use replicas (3)
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Should calculate minAvailable as sum: 1 (task-1 minAvailable) + 3 (task-2 replicas) = 4
+		gomega.Expect(createdJob.Spec.MinAvailable).To(gomega.Equal(int32(4)))
+	})
+
+	// NOTE: Task-level mutation tests removed because MutatingAdmissionPolicy
+	// cannot handle dynamic iteration over arbitrary number of tasks.
+	// These mutations would require hardcoded rules for each task index (0, 1, 2, etc.)
+	// which is not scalable. Task-level mutations are handled by the webhook implementation.
+	//
+	// Removed tests:
+	// - Should generate default task names when not specified
+	// - Should set DNS policy for hostNetwork pods
+	// - Should set default task-level minAvailable when not specified
+	// - Should set default task-level maxRetry when not specified
+
+	ginkgo.It("Should add svc plugin for tensorflow plugin", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tensorflow-plugin-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				Plugins: map[string][]string{
+					"tensorflow": {},
+					// svc plugin not specified, should be added automatically
+				},
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "task-1",
+						Replicas: 1,
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("svc"))
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("tensorflow"))
+	})
+
+	ginkgo.It("Should add svc plugin for mpi plugin", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mpi-plugin-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				Plugins: map[string][]string{
+					// Provide master/worker names so admission validator can find the tasks
+					"mpi": {"--master=task-1", "--worker=task-1"},
+					// svc plugin not specified, should be added automatically
+				},
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "task-1",
+						Replicas: 1,
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("svc"))
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("mpi"))
+	})
+
+	ginkgo.It("Should add svc plugin for pytorch plugin", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pytorch-plugin-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				Plugins: map[string][]string{
+					"pytorch": {},
+					// svc plugin not specified, should be added automatically
+				},
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "task-1",
+						Replicas: 1,
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("svc"))
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("pytorch"))
+	})
+
+	ginkgo.It("Should add ssh plugin for mpi plugin", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mpi-ssh-plugin-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				Plugins: map[string][]string{
+					// Provide master/worker names so admission validator can find the tasks
+					"mpi": {"--master=task-1", "--worker=task-1"},
+					// ssh plugin not specified, should be added automatically
+				},
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "task-1",
+						Replicas: 1,
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("ssh"))
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("mpi"))
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("svc")) // Should also have svc plugin
+	})
+
+	ginkgo.It("Should not override existing plugins", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "existing-plugins-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				Plugins: map[string][]string{
+					"tensorflow": {},
+					"svc":        {"--enable-networking"}, // Already specified with arguments
+				},
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "task-1",
+						Replicas: 1,
+						Template: createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("svc"))
+		gomega.Expect(createdJob.Spec.Plugins).To(gomega.HaveKey("tensorflow"))
+		// Should preserve existing svc plugin arguments
+		gomega.Expect(createdJob.Spec.Plugins["svc"]).To(gomega.ContainElement("--enable-networking"))
+	})
+
+	ginkgo.It("Should preserve existing field values when specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		customMinAvailable := int32(2)
+		customQueue := "custom-queue-job"
+		// First create custom-queue-job
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      customQueue,
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		// Poll and wait for queue status to be open
+		gomega.Eventually(func() string {
+			q, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), customQueue, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return string(q.Status.State)
+		}, 30, 1).Should(gomega.Equal("Open"))
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "preserve-values-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable:  2,              // Explicitly specified
+				Queue:         customQueue,    // Explicitly specified
+				SchedulerName: "custom-sched", // Explicitly specified
+				MaxRetry:      10,             // Explicitly specified
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:         "custom-task", // Explicitly specified
+						Replicas:     3,
+						MinAvailable: &customMinAvailable, // Explicitly specified
+						MaxRetry:     5,                   // Explicitly specified
+						Template:     createPodTemplateForMutation(),
+					},
+				},
+			},
+		}
+
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Should preserve all explicitly specified values
+		gomega.Expect(createdJob.Spec.MinAvailable).To(gomega.Equal(int32(2)))
+		gomega.Expect(createdJob.Spec.Queue).To(gomega.Equal(customQueue))
+		gomega.Expect(createdJob.Spec.SchedulerName).To(gomega.Equal("custom-sched"))
+		gomega.Expect(createdJob.Spec.MaxRetry).To(gomega.Equal(int32(10)))
+		gomega.Expect(createdJob.Spec.Tasks[0].Name).To(gomega.Equal("custom-task"))
+		gomega.Expect(*createdJob.Spec.Tasks[0].MinAvailable).To(gomega.Equal(int32(2)))
+		gomega.Expect(createdJob.Spec.Tasks[0].MaxRetry).To(gomega.Equal(int32(5)))
+	})
+})
+
+// Helper function to create a basic pod template for job mutation tests
+func createPodTemplateForMutation() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"name": "test"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "fake-name",
+					Image: "busybox:1.24",
+				},
+			},
+		},
+	}
+}

--- a/test/e2e/admission/job_validation_test.go
+++ b/test/e2e/admission/job_validation_test.go
@@ -1,0 +1,598 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/apis/pkg/apis/batch/v1alpha1"
+	busv1alpha1 "volcano.sh/apis/pkg/apis/bus/v1alpha1"
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("Job Validating E2E Test", func() {
+
+	ginkgo.It("Should allow job creation with valid configuration", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("valid-job", testCtx.Namespace)
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject job creation with duplicate task names", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "duplicate-task-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "duplicated-task",
+						Replicas: 1,
+						Template: createPodTemplate(),
+					},
+					{
+						Name:     "duplicated-task",
+						Replicas: 1,
+						Template: createPodTemplate(),
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("duplicated task name"))
+	})
+
+	ginkgo.It("Should reject job creation with invalid minAvailable less than zero", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-min-available-job", testCtx.Namespace)
+		job.Spec.MinAvailable = -1
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("job 'minAvailable' must be >= 0"))
+	})
+
+	ginkgo.It("Should reject job creation with invalid maxRetry less than zero", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-max-retry-job", testCtx.Namespace)
+		job.Spec.MaxRetry = -1
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("'maxRetry' cannot be less than zero"))
+	})
+
+	ginkgo.It("Should reject job creation with invalid TTLSecondsAfterFinished less than zero", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-ttl-job", testCtx.Namespace)
+		invalidTTL := int32(-1)
+		job.Spec.TTLSecondsAfterFinished = &invalidTTL
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("'ttlSecondsAfterFinished' cannot be less than zero"))
+	})
+
+	ginkgo.It("Should reject job creation with no tasks specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-task-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				Tasks:        []v1alpha1.TaskSpec{},
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("No task specified in job spec"))
+	})
+
+	ginkgo.It("Should reject job creation with task replicas less than zero", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-replica-job", testCtx.Namespace)
+		job.Spec.Tasks[0].Replicas = -1
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("'replicas' < 0 in task"))
+	})
+
+	ginkgo.It("Should reject job creation with task minAvailable less than zero", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-task-min-available-job", testCtx.Namespace)
+		invalidMinAvailable := int32(-1)
+		job.Spec.Tasks[0].MinAvailable = &invalidMinAvailable
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("'minAvailable' < 0 in task"))
+	})
+
+	ginkgo.It("Should reject job creation with task minAvailable greater than replicas", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-task-min-available-gt-replicas-job", testCtx.Namespace)
+		invalidMinAvailable := int32(5)
+		job.Spec.Tasks[0].Replicas = 3
+		job.Spec.Tasks[0].MinAvailable = &invalidMinAvailable
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("'minAvailable' is greater than 'replicas' in task"))
+	})
+
+	ginkgo.It("Should reject job creation with job minAvailable greater than total replicas", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-job-min-available-job", testCtx.Namespace)
+		job.Spec.MinAvailable = 5
+		job.Spec.Tasks[0].Replicas = 1
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("job 'minAvailable' should not be greater than total replicas"))
+	})
+
+	ginkgo.It("Should reject job creation with invalid task name (non-DNS1123)", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-task-name-job", testCtx.Namespace)
+		job.Spec.Tasks[0].Name = "Task-1" // Uppercase not allowed
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("a lowercase RFC 1123 label must consist of lower case alphanumeric characters"))
+	})
+
+	ginkgo.It("Should reject job creation with duplicate policy events", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("duplicate-policy-job", testCtx.Namespace)
+		job.Spec.Policies = []v1alpha1.LifecyclePolicy{
+			{
+				Event:  busv1alpha1.PodFailedEvent,
+				Action: busv1alpha1.AbortJobAction,
+			},
+			{
+				Event:  busv1alpha1.PodFailedEvent,
+				Action: busv1alpha1.RestartJobAction,
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("duplicate"))
+	})
+
+	ginkgo.It("Should reject job creation with policy event and exit code specified simultaneously", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-policy-event-exitcode-job", testCtx.Namespace)
+		exitCode := int32(1)
+		job.Spec.Policies = []v1alpha1.LifecyclePolicy{
+			{
+				Event:    busv1alpha1.PodFailedEvent,
+				Action:   busv1alpha1.AbortJobAction,
+				ExitCode: &exitCode,
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("must not specify event and exitCode simultaneously"))
+	})
+
+	ginkgo.It("Should reject job creation with policy having neither event nor exit code", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-policy-no-event-no-exitcode-job", testCtx.Namespace)
+		job.Spec.Policies = []v1alpha1.LifecyclePolicy{
+			{
+				Action: busv1alpha1.AbortJobAction,
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("either event and exitCode should be specified"))
+	})
+
+	ginkgo.It("Should reject job creation with invalid policy action", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-policy-action-job", testCtx.Namespace)
+		job.Spec.Policies = []v1alpha1.LifecyclePolicy{
+			{
+				Event:  busv1alpha1.PodEvictedEvent,
+				Action: busv1alpha1.Action("InvalidAction"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("invalid policy action"))
+	})
+
+	ginkgo.It("Should reject job creation with policy exit code zero", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-policy-exitcode-zero-job", testCtx.Namespace)
+		exitCode := int32(0)
+		job.Spec.Policies = []v1alpha1.LifecyclePolicy{
+			{
+				Action:   busv1alpha1.AbortJobAction,
+				ExitCode: &exitCode,
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("0 is not a valid error code"))
+	})
+
+	ginkgo.It("Should reject job creation with duplicate policy exit codes", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("duplicate-policy-exitcode-job", testCtx.Namespace)
+		exitCode1 := int32(1)
+		exitCode2 := int32(1)
+		job.Spec.Policies = []v1alpha1.LifecyclePolicy{
+			{
+				Action:   busv1alpha1.AbortJobAction,
+				ExitCode: &exitCode1,
+			},
+			{
+				Action:   busv1alpha1.RestartJobAction,
+				ExitCode: &exitCode2,
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("duplicate exitCode"))
+	})
+
+	ginkgo.It("Should reject job creation with AnyEvent policy and other event policies", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-any-event-policy-job", testCtx.Namespace)
+		job.Spec.Policies = []v1alpha1.LifecyclePolicy{
+			{
+				Event:  busv1alpha1.AnyEvent,
+				Action: busv1alpha1.AbortJobAction,
+			},
+			{
+				Event:  busv1alpha1.PodFailedEvent,
+				Action: busv1alpha1.RestartJobAction,
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("if there's * here, no other policy should be here"))
+	})
+
+	ginkgo.It("Should reject job creation with invalid volume mount path", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-volume-mount-job", testCtx.Namespace)
+		job.Spec.Volumes = []v1alpha1.VolumeSpec{
+			{
+				MountPath: "", // Empty mount path
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("mountPath is required"))
+	})
+
+	ginkgo.It("Should reject job creation with duplicate volume mount paths", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("duplicate-volume-mount-job", testCtx.Namespace)
+		job.Spec.Volumes = []v1alpha1.VolumeSpec{
+			{
+				MountPath:       "/var",
+				VolumeClaimName: "pvc1",
+			},
+			{
+				MountPath:       "/var",
+				VolumeClaimName: "pvc2",
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("duplicated mountPath"))
+	})
+
+	ginkgo.It("Should reject job creation with volume without claim name or claim spec", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-volume-no-claim-job", testCtx.Namespace)
+		job.Spec.Volumes = []v1alpha1.VolumeSpec{
+			{
+				MountPath: "/var",
+				// Neither VolumeClaimName nor VolumeClaim specified
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("either VolumeClaim or VolumeClaimName must be specified"))
+	})
+
+	ginkgo.It("Should allow job creation with valid task dependencies (DAG)", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := &v1alpha1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "valid-dag-job",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: v1alpha1.JobSpec{
+				MinAvailable: 1,
+				Queue:        "default",
+				Tasks: []v1alpha1.TaskSpec{
+					{
+						Name:     "t1",
+						Replicas: 1,
+						DependsOn: &v1alpha1.DependsOn{
+							Name: []string{"t2"},
+						},
+						Template: createPodTemplate(),
+					},
+					{
+						Name:     "t2",
+						Replicas: 1,
+						Template: createPodTemplate(),
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow job update with valid changes to minAvailable and replicas", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("update-job", testCtx.Namespace)
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Update minAvailable and task replicas with retry on conflict
+		var updateErr error
+		for retryCount := 0; retryCount < 5; retryCount++ {
+			// Fetch the latest version before updating
+			latestJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Get(context.TODO(), createdJob.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Update minAvailable and task replicas
+			latestJob.Spec.MinAvailable = 3
+			latestJob.Spec.Tasks[0].Replicas = 5
+
+			_, updateErr = testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Update(context.TODO(), latestJob, metav1.UpdateOptions{})
+			// If we get a conflict, retry with fresh object
+			if errors.IsConflict(updateErr) {
+				continue
+			}
+			// For any other error or success, break
+			break
+		}
+		gomega.Expect(updateErr).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject job update with invalid minAvailable greater than total replicas", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("invalid-update-job", testCtx.Namespace)
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Retry update with fresh object on conflict, but expect validation error
+		var updateErr error
+		for retryCount := 0; retryCount < 5; retryCount++ {
+			// Fetch the latest version before updating
+			latestJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Get(context.TODO(), createdJob.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Set minAvailable greater than replicas
+			latestJob.Spec.MinAvailable = 10
+			latestJob.Spec.Tasks[0].Replicas = 5
+
+			_, updateErr = testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Update(context.TODO(), latestJob, metav1.UpdateOptions{})
+			// If we get a conflict, retry with fresh object
+			if errors.IsConflict(updateErr) {
+				continue
+			}
+			// For any other error (including validation errors), break and check
+			break
+		}
+
+		// We expect an error containing our validation message
+		gomega.Expect(updateErr).To(gomega.HaveOccurred())
+		gomega.Expect(updateErr.Error()).To(gomega.ContainSubstring("not be greater than total replicas"))
+	})
+
+	ginkgo.It("Should reject job update attempting to add new tasks", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("add-task-update-job", testCtx.Namespace)
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Retry update with fresh object on conflict, but expect validation error
+		var updateErr error
+		for retryCount := 0; retryCount < 5; retryCount++ {
+			// Fetch the latest version before updating
+			latestJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Get(context.TODO(), createdJob.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Try to add a new task
+			newTask := v1alpha1.TaskSpec{
+				Name:     "new-task",
+				Replicas: 2,
+				Template: createPodTemplate(),
+			}
+			latestJob.Spec.Tasks = append(latestJob.Spec.Tasks, newTask)
+
+			_, updateErr = testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Update(context.TODO(), latestJob, metav1.UpdateOptions{})
+			// If we get a conflict, retry with fresh object
+			if errors.IsConflict(updateErr) {
+				continue
+			}
+			// For any other error (including validation errors), break and check
+			break
+		}
+
+		// We expect an error containing our validation message
+		gomega.Expect(updateErr).To(gomega.HaveOccurred())
+		gomega.Expect(updateErr.Error()).To(gomega.ContainSubstring("job updates may not add or remove tasks"))
+	})
+
+	ginkgo.It("Should reject job update attempting to change queue name", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		job := createBaseJob("change-queue-update-job", testCtx.Namespace)
+		createdJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Create(context.TODO(), job, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Retry update with fresh object on conflict, but expect validation error
+		var updateErr error
+		for retryCount := 0; retryCount < 5; retryCount++ {
+			// Fetch the latest version before updating
+			latestJob, err := testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Get(context.TODO(), createdJob.Name, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Try to change queue name
+			latestJob.Spec.Queue = "another-queue"
+
+			_, updateErr = testCtx.Vcclient.BatchV1alpha1().Jobs(testCtx.Namespace).Update(context.TODO(), latestJob, metav1.UpdateOptions{})
+			// If we get a conflict, retry with fresh object
+			if errors.IsConflict(updateErr) {
+				continue
+			}
+			// For any other error (including validation errors), break and check
+			break
+		}
+
+		// We expect an error containing our validation message
+		gomega.Expect(updateErr).To(gomega.HaveOccurred())
+		gomega.Expect(updateErr.Error()).To(gomega.ContainSubstring("job updates may not change fields other than"))
+	})
+})
+
+// Helper function to create a base valid job
+func createBaseJob(name, namespace string) *v1alpha1.Job {
+	return &v1alpha1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.JobSpec{
+			MinAvailable: 1,
+			Queue:        "default",
+			Tasks: []v1alpha1.TaskSpec{
+				{
+					Name:     "task-1",
+					Replicas: 1,
+					Template: createPodTemplate(),
+				},
+			},
+			Policies: []v1alpha1.LifecyclePolicy{
+				{
+					Event:  busv1alpha1.PodEvictedEvent,
+					Action: busv1alpha1.RestartTaskAction,
+				},
+			},
+		},
+	}
+}
+
+// Helper function to create a basic pod template
+func createPodTemplate() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"name": "test"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "fake-name",
+					Image: "busybox:1.24",
+				},
+			},
+		},
+	}
+}

--- a/test/e2e/admission/jobflow_validation_test.go
+++ b/test/e2e/admission/jobflow_validation_test.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	flowv1alpha1 "volcano.sh/apis/pkg/apis/flow/v1alpha1"
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("JobFlow Validating E2E Test", func() {
+
+	ginkgo.It("Should allow jobflow creation with valid DAG structure", func() {
+		jobFlowName := "valid-dag-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows: []flowv1alpha1.Flow{
+					{
+						Name: "a",
+					},
+					{
+						Name: "b",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"a"},
+						},
+					},
+					{
+						Name: "c",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"a", "b"},
+						},
+					},
+					{
+						Name: "d",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"b"},
+						},
+					},
+					{
+						Name: "e",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"c", "d"},
+						},
+					},
+				},
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow jobflow creation with duplicate flow names", func() {
+		jobFlowName := "duplicate-names-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows: []flowv1alpha1.Flow{
+					{
+						Name: "a",
+					},
+					{
+						Name: "a", // Duplicate name
+					},
+					{
+						Name: "b",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"a"},
+						},
+					},
+				},
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject jobflow creation with missing flow definition", func() {
+		jobFlowName := "missing-flow-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows: []flowv1alpha1.Flow{
+					{
+						Name: "b",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"a"}, // "a" is not defined
+						},
+					},
+					{
+						Name: "c",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"a", "b"},
+						},
+					},
+				},
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("jobflow Flow is not DAG"))
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("vertex is not defined"))
+	})
+
+	ginkgo.It("Should allow jobflow creation with multiple flows having same dependency target", func() {
+		jobFlowName := "multi-dependency-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows: []flowv1alpha1.Flow{
+					{
+						Name: "a",
+					},
+					{
+						Name: "b",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"a"},
+						},
+					},
+					{
+						Name: "c",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"a"}, // Same dependency as "b"
+						},
+					},
+					{
+						Name: "c", // Duplicate name with different dependency
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"b"},
+						},
+					},
+				},
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow jobflow update with valid DAG structure", func() {
+		jobFlowName := "update-valid-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// Create initial jobflow
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows: []flowv1alpha1.Flow{
+					{
+						Name: "a",
+					},
+					{
+						Name: "b",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"a"},
+						},
+					},
+				},
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		createdJobFlow, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Update with valid DAG structure
+		createdJobFlow.Spec.Flows = append(createdJobFlow.Spec.Flows, flowv1alpha1.Flow{
+			Name: "c",
+			DependsOn: &flowv1alpha1.DependsOn{
+				Targets: []string{"b"},
+			},
+		})
+
+		_, err = testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Update(context.TODO(), createdJobFlow, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow jobflow creation with simple linear dependency chain", func() {
+		jobFlowName := "linear-dependency-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows: []flowv1alpha1.Flow{
+					{
+						Name: "start",
+					},
+					{
+						Name: "middle",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"start"},
+						},
+					},
+					{
+						Name: "end",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"middle"},
+						},
+					},
+				},
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow jobflow creation with complex valid DAG structure", func() {
+		jobFlowName := "complex-dag-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows: []flowv1alpha1.Flow{
+					{
+						Name: "root1",
+					},
+					{
+						Name: "root2",
+					},
+					{
+						Name: "level1-a",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"root1"},
+						},
+					},
+					{
+						Name: "level1-b",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"root2"},
+						},
+					},
+					{
+						Name: "level2",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"level1-a", "level1-b"},
+						},
+					},
+					{
+						Name: "final",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"level2"},
+						},
+					},
+				},
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow jobflow creation with empty flows list", func() {
+		jobFlowName := "empty-flows-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows:           []flowv1alpha1.Flow{}, // Empty flows
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow jobflow creation with single flow (no dependencies)", func() {
+		jobFlowName := "single-flow-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows: []flowv1alpha1.Flow{
+					{
+						Name: "single-flow",
+					},
+				},
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject jobflow creation with self-dependency", func() {
+		jobFlowName := "self-dependency-jobflow"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		jobFlow := &flowv1alpha1.JobFlow{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      jobFlowName,
+			},
+			Spec: flowv1alpha1.JobFlowSpec{
+				Flows: []flowv1alpha1.Flow{
+					{
+						Name: "self-dependent",
+						DependsOn: &flowv1alpha1.DependsOn{
+							Targets: []string{"self-dependent"}, // Self dependency
+						},
+					},
+				},
+				JobRetainPolicy: flowv1alpha1.RetainPolicy("retain"),
+			},
+		}
+
+		_, err := testCtx.Vcclient.FlowV1alpha1().JobFlows(testCtx.Namespace).Create(context.TODO(), jobFlow, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("jobflow Flow is not DAG"))
+	})
+})

--- a/test/e2e/admission/main_test.go
+++ b/test/e2e/admission/main_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	vcclient "volcano.sh/apis/pkg/client/clientset/versioned"
+
+	e2eutil "volcano.sh/volcano/test/e2e/util"
+)
+
+func TestMain(m *testing.M) {
+	home := e2eutil.HomeDir()
+	configPath := e2eutil.KubeconfigPath(home)
+	config, _ := clientcmd.BuildConfigFromFlags(e2eutil.MasterURL(), configPath)
+	e2eutil.VcClient = vcclient.NewForConfigOrDie(config)
+	e2eutil.KubeClient = kubernetes.NewForConfigOrDie(config)
+	os.Exit(m.Run())
+}

--- a/test/e2e/admission/pod_mutate_test.go
+++ b/test/e2e/admission/pod_mutate_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("Pod Mutating E2E Test", func() {
+
+	ginkgo.It("Should add nodeSelector for management namespace pods", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// Create a pod in management namespace that should get nodeSelector added
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "management-pod",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		gomega.Expect(createdPod.Spec.NodeSelector).To(gomega.BeNil())
+	})
+
+	ginkgo.It("Should add nodeSelector for pods with cpu resource-group annotation", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cpu-pod",
+				Namespace: testCtx.Namespace,
+				Annotations: map[string]string{
+					"volcano.sh/resource-group": "cpu",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Since  configuration is set in test environment,
+		// the pod should not be mutated and nodeSelector should remain nil
+		gomega.Expect(createdPod.Spec.NodeSelector).To(gomega.BeNil())
+		// Verify the annotation is preserved
+		gomega.Expect(createdPod.Annotations).To(gomega.HaveKey("volcano.sh/resource-group"))
+		gomega.Expect(createdPod.Annotations["volcano.sh/resource-group"]).To(gomega.Equal("cpu"))
+	})
+
+	ginkgo.It("Should add nodeSelector for pods with gpu resource-group annotation", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gpu-pod",
+				Namespace: testCtx.Namespace,
+				Annotations: map[string]string{
+					"volcano.sh/resource-group": "gpu",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Since  configuration is set in test environment,
+		// the pod should not be mutated and nodeSelector should remain nil
+		gomega.Expect(createdPod.Spec.NodeSelector).To(gomega.BeNil())
+		// Verify the annotation is preserved
+		gomega.Expect(createdPod.Annotations).To(gomega.HaveKey("volcano.sh/resource-group"))
+		gomega.Expect(createdPod.Annotations["volcano.sh/resource-group"]).To(gomega.Equal("gpu"))
+	})
+
+	ginkgo.It("Should add affinity for management namespace pods", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "affinity-pod",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: corev1.PodSpec{
+				// No existing affinity - should be added by webhook
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify affinity is added based on configuration
+		// Note: The actual affinity configuration depends on webhook setup
+		if createdPod.Spec.Affinity != nil {
+			gomega.Expect(createdPod.Spec.Affinity.NodeAffinity).NotTo(gomega.BeNil())
+		}
+	})
+
+	ginkgo.It("Should not override existing affinity", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		existingAffinity := &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{
+									Key:      "custom-key",
+									Operator: corev1.NodeSelectorOpIn,
+									Values:   []string{"custom-value"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "existing-affinity-pod",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: corev1.PodSpec{
+				Affinity: existingAffinity,
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify existing affinity is preserved
+		gomega.Expect(createdPod.Spec.Affinity).NotTo(gomega.BeNil())
+		gomega.Expect(createdPod.Spec.Affinity.NodeAffinity).NotTo(gomega.BeNil())
+		gomega.Expect(createdPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution).NotTo(gomega.BeNil())
+		gomega.Expect(createdPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(gomega.HaveLen(1))
+		gomega.Expect(createdPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions).To(gomega.HaveLen(1))
+		gomega.Expect(createdPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Key).To(gomega.Equal("custom-key"))
+	})
+
+	ginkgo.It("Should add tolerations for management namespace pods", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tolerations-pod",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify tolerations are added based on configuration
+		if len(createdPod.Spec.Tolerations) > 0 {
+			// Check for management-related tolerations based on unit test expectations
+			foundManagementToleration := false
+			for _, toleration := range createdPod.Spec.Tolerations {
+				if toleration.Key == "mng-taint-1" || toleration.Effect == corev1.TaintEffectNoSchedule {
+					foundManagementToleration = true
+					break
+				}
+			}
+			if foundManagementToleration {
+				gomega.Expect(foundManagementToleration).To(gomega.BeTrue())
+			}
+		}
+	})
+
+	ginkgo.It("Should append tolerations to existing ones", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		existingTolerations := []corev1.Toleration{
+			{
+				Key:      "existing-taint",
+				Operator: corev1.TolerationOpEqual,
+				Value:    "existing-value",
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "existing-tolerations-pod",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: corev1.PodSpec{
+				Tolerations: existingTolerations,
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify existing tolerations are preserved and new ones are appended
+		gomega.Expect(len(createdPod.Spec.Tolerations)).To(gomega.BeNumerically(">=", 1))
+
+		// Check that original toleration is still present
+		foundExistingToleration := false
+		for _, toleration := range createdPod.Spec.Tolerations {
+			if toleration.Key == "existing-taint" {
+				foundExistingToleration = true
+				break
+			}
+		}
+		gomega.Expect(foundExistingToleration).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("Should set scheduler name based on resource group", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "scheduler-pod",
+				Namespace: testCtx.Namespace,
+				Annotations: map[string]string{
+					"volcano.sh/resource-group": "cpu",
+				},
+			},
+			Spec: corev1.PodSpec{
+				// No scheduler name specified - should be set by webhook
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Since  configuration is set in test environment,
+		// the scheduler name should be the default Kubernetes scheduler
+		gomega.Expect(createdPod.Spec.SchedulerName).To(gomega.Equal("default-scheduler"))
+	})
+
+	ginkgo.It("Should merge nodeSelector with existing ones", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		existingNodeSelector := map[string]string{
+			"existing-label": "existing-value",
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "merge-nodeselector-pod",
+				Namespace: testCtx.Namespace,
+				Annotations: map[string]string{
+					"volcano.sh/resource-group": "cpu",
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeSelector: existingNodeSelector,
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify existing nodeSelector is preserved and new labels are added
+		gomega.Expect(createdPod.Spec.NodeSelector).NotTo(gomega.BeNil())
+		gomega.Expect(createdPod.Spec.NodeSelector).To(gomega.HaveKey("existing-label"))
+		gomega.Expect(createdPod.Spec.NodeSelector["existing-label"]).To(gomega.Equal("existing-value"))
+
+		// Check if volcano nodetype label is also added
+		if len(createdPod.Spec.NodeSelector) > 1 {
+			gomega.Expect(createdPod.Spec.NodeSelector).To(gomega.HaveKey("volcano.sh/nodetype"))
+		}
+	})
+
+	ginkgo.It("Should not mutate pods that don't match any resource group", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "normal-pod",
+				Namespace: testCtx.Namespace,
+				// No annotations or special namespace - shouldn't match any resource group
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		gomega.Expect(createdPod.Spec.NodeSelector).To(gomega.BeNil())
+		gomega.Expect(createdPod.Spec.Affinity).To(gomega.BeNil())
+		gomega.Expect(createdPod.Spec.SchedulerName).To(gomega.Equal("default-scheduler"))
+		// Note: tolerations might be added by Kubernetes for system taints, so we don't check for empty tolerations
+	})
+
+	ginkgo.It("Should handle pods with custom annotation-based resource group matching", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "custom-annotation-pod",
+				Namespace: testCtx.Namespace,
+				Annotations: map[string]string{
+					"volcano.sh/resource-group": "custom-group",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Pod created successfully - mutation behavior depends on webhook configuration
+		// for the custom-group resource group
+		gomega.Expect(createdPod.Name).To(gomega.Equal("custom-annotation-pod"))
+		gomega.Expect(createdPod.Annotations).To(gomega.HaveKey("volcano.sh/resource-group"))
+		gomega.Expect(createdPod.Annotations["volcano.sh/resource-group"]).To(gomega.Equal("custom-group"))
+	})
+
+	ginkgo.It("Should preserve existing scheduler name when already specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		existingScheduler := "custom-scheduler"
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "existing-scheduler-pod",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: existingScheduler,
+				Containers: []corev1.Container{
+					{
+						Name:  "test-container",
+						Image: "busybox:1.24",
+					},
+				},
+			},
+		}
+
+		createdPod, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Verify existing scheduler name is preserved
+		gomega.Expect(createdPod.Spec.SchedulerName).To(gomega.Equal(existingScheduler))
+	})
+})

--- a/test/e2e/admission/pod_validation_test.go
+++ b/test/e2e/admission/pod_validation_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("Pod Validating E2E Test", func() {
+
+	ginkgo.It("Should allow pod creation with valid annotations", func() {
+		podName := "valid-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+				Annotations: map[string]string{
+					schedulingv1beta1.JDBMinAvailable: "2",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "volcano",
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = util.WaitPodPhase(testCtx, pod, []corev1.PodPhase{corev1.PodPending, corev1.PodRunning})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow pod creation with valid percentage annotation", func() {
+		podName := "valid-percentage-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+				Annotations: map[string]string{
+					schedulingv1beta1.JDBMaxUnavailable: "50%",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "volcano",
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = util.WaitPodPhase(testCtx, pod, []corev1.PodPhase{corev1.PodPending, corev1.PodRunning})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject pod creation with invalid negative annotation value", func() {
+		podName := "invalid-negative-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+				Annotations: map[string]string{
+					schedulingv1beta1.JDBMinAvailable: "-1",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "volcano",
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("must be a positive integer"))
+	})
+
+	ginkgo.It("Should reject pod creation with invalid zero annotation value", func() {
+		podName := "invalid-zero-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+				Annotations: map[string]string{
+					schedulingv1beta1.JDBMinAvailable: "0",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "volcano",
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("must be a positive integer"))
+	})
+
+	ginkgo.It("Should reject pod creation with invalid percentage annotation (0%)", func() {
+		podName := "invalid-zero-percent-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+				Annotations: map[string]string{
+					schedulingv1beta1.JDBMaxUnavailable: "0%",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "volcano",
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("percentage which between 1% ~ 99%"))
+	})
+
+	ginkgo.It("Should reject pod creation with invalid percentage annotation (100%)", func() {
+		podName := "invalid-hundred-percent-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+				Annotations: map[string]string{
+					schedulingv1beta1.JDBMaxUnavailable: "100%",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "volcano",
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("percentage which between 1% ~ 99%"))
+	})
+
+	ginkgo.It("Should reject pod creation with invalid string annotation", func() {
+		podName := "invalid-string-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+				Annotations: map[string]string{
+					schedulingv1beta1.JDBMinAvailable: "invalid",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "volcano",
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject pod creation with multiple conflicting annotations", func() {
+		podName := "conflicting-annotations-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+				Annotations: map[string]string{
+					schedulingv1beta1.JDBMinAvailable:   "2",
+					schedulingv1beta1.JDBMaxUnavailable: "50%",
+				},
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "volcano",
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("not allow configure multiple annotations"))
+	})
+
+	ginkgo.It("Should allow pod creation without annotations when using volcano scheduler", func() {
+		podName := "no-annotations-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "volcano",
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = util.WaitPodPhase(testCtx, pod, []corev1.PodPhase{corev1.PodPending, corev1.PodRunning})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow pod creation with non-volcano scheduler (bypass validation)", func() {
+		podName := "non-volcano-scheduler-pod"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      podName,
+				Annotations: map[string]string{
+					schedulingv1beta1.JDBMinAvailable: "-1", // This would normally fail validation
+				},
+			},
+			Spec: corev1.PodSpec{
+				SchedulerName: "default-scheduler", // Using default scheduler, not volcano
+				Containers:    util.CreateContainers(util.DefaultNginxImage, "", "", util.OneCPU, util.OneCPU, 0),
+			},
+		}
+
+		_, err := testCtx.Kubeclient.CoreV1().Pods(testCtx.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = util.WaitPodPhase(testCtx, pod, []corev1.PodPhase{corev1.PodPending, corev1.PodRunning})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+})

--- a/test/e2e/admission/podgroup_mutate_test.go
+++ b/test/e2e/admission/podgroup_mutate_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("PodGroup Mutating E2E Test", func() {
+
+	ginkgo.It("Should not modify podgroup with custom queue", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		customQueue := "custom-queue-podgroup"
+		// First create custom-queue-podgroup
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      customQueue,
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Poll and wait for queue status to be open
+		gomega.Eventually(func() string {
+			q, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), customQueue, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return string(q.Status.State)
+		}, 30, 1).Should(gomega.Equal("Open")) // 30 seconds timeout, 1 second interval
+
+		podgroup := &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "custom-queue-podgroup",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.PodGroupSpec{
+				Queue:        customQueue,
+				MinMember:    1,
+				MinResources: nil,
+			},
+		}
+
+		createdPodGroup, err := testCtx.Vcclient.SchedulingV1beta1().PodGroups(testCtx.Namespace).Create(context.TODO(), podgroup, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdPodGroup.Spec.Queue).To(gomega.Equal(customQueue))
+	})
+
+	ginkgo.It("Should set queue from namespace annotation when podgroup uses default queue", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// First, update the namespace with queue annotation
+		namespaceQueueName := "namespace-queue"
+		ns, err := testCtx.Kubeclient.CoreV1().Namespaces().Get(context.TODO(), testCtx.Namespace, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+		ns.Annotations[schedulingv1beta1.QueueNameAnnotationKey] = namespaceQueueName
+
+		_, err = testCtx.Kubeclient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// First create namespace-queue
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namespaceQueueName,
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+		_, err = testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Poll and wait for queue status to be open
+		gomega.Eventually(func() string {
+			q, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), namespaceQueueName, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return string(q.Status.State)
+		}, 30, 1).Should(gomega.Equal("Open"))
+
+		// Create podgroup with default queue
+		podgroup := &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-queue-podgroup",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.PodGroupSpec{
+				Queue:        schedulingv1beta1.DefaultQueue,
+				MinMember:    1,
+				MinResources: nil,
+			},
+		}
+
+		createdPodGroup, err := testCtx.Vcclient.SchedulingV1beta1().PodGroups(testCtx.Namespace).Create(context.TODO(), podgroup, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdPodGroup.Spec.Queue).To(gomega.Equal(namespaceQueueName))
+	})
+
+	ginkgo.It("Should keep default queue when namespace has no queue annotation", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// Ensure namespace has no queue annotation
+		ns, err := testCtx.Kubeclient.CoreV1().Namespaces().Get(context.TODO(), testCtx.Namespace, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if ns.Annotations != nil {
+			delete(ns.Annotations, schedulingv1beta1.QueueNameAnnotationKey)
+			_, err = testCtx.Kubeclient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		// Create podgroup with default queue
+		podgroup := &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-annotation-podgroup",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.PodGroupSpec{
+				Queue:        schedulingv1beta1.DefaultQueue,
+				MinMember:    1,
+				MinResources: nil,
+			},
+		}
+
+		createdPodGroup, err := testCtx.Vcclient.SchedulingV1beta1().PodGroups(testCtx.Namespace).Create(context.TODO(), podgroup, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdPodGroup.Spec.Queue).To(gomega.Equal(schedulingv1beta1.DefaultQueue))
+	})
+
+	ginkgo.It("Should handle multiple podgroups in same namespace", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// Set queue annotation in namespace
+		namespaceQueueName := "namespace-queue-multiple"
+		ns, err := testCtx.Kubeclient.CoreV1().Namespaces().Get(context.TODO(), testCtx.Namespace, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+		ns.Annotations[schedulingv1beta1.QueueNameAnnotationKey] = namespaceQueueName
+
+		_, err = testCtx.Kubeclient.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// First create namespace-queue-multiple
+		queue1 := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namespaceQueueName,
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+		_, err = testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue1, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Eventually(func() string {
+			q, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), namespaceQueueName, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return string(q.Status.State)
+		}, 30, 1).Should(gomega.Equal("Open"))
+
+		// Then create custom-queue-podgroup-2
+		customQueue := "custom-queue-podgroup-2"
+		queue2 := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      customQueue,
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+		_, err = testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue2, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Eventually(func() string {
+			q, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), customQueue, metav1.GetOptions{})
+			if err != nil {
+				return ""
+			}
+			return string(q.Status.State)
+		}, 30, 1).Should(gomega.Equal("Open"))
+
+		// Create multiple podgroups with different queue configurations
+		podgroup1 := &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multiple-1-default",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.PodGroupSpec{
+				Queue:        schedulingv1beta1.DefaultQueue,
+				MinMember:    1,
+				MinResources: nil,
+			},
+		}
+
+		podgroup2 := &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multiple-2-custom",
+				Namespace: testCtx.Namespace,
+			},
+			Spec: schedulingv1beta1.PodGroupSpec{
+				Queue:        customQueue,
+				MinMember:    1,
+				MinResources: nil,
+			},
+		}
+
+		createdPodGroup1, err := testCtx.Vcclient.SchedulingV1beta1().PodGroups(testCtx.Namespace).Create(context.TODO(), podgroup1, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		createdPodGroup2, err := testCtx.Vcclient.SchedulingV1beta1().PodGroups(testCtx.Namespace).Create(context.TODO(), podgroup2, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// First podgroup should be mutated to use namespace queue
+		gomega.Expect(createdPodGroup1.Spec.Queue).To(gomega.Equal(namespaceQueueName))
+
+		// Second podgroup should keep its custom queue
+		gomega.Expect(createdPodGroup2.Spec.Queue).To(gomega.Equal(customQueue))
+	})
+})

--- a/test/e2e/admission/podgroup_validation_test.go
+++ b/test/e2e/admission/podgroup_validation_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("PodGroup Validating E2E Test", func() {
+
+	// Test PodGroup creation with valid queue (Open state)
+	ginkgo.It("Should allow PodGroup creation with valid open queue", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// First create a queue with Open state
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-open",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+
+		createdQueue, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Small delay to ensure mutation is complete
+		time.Sleep(100 * time.Millisecond)
+
+		// Get the latest version of the queue after potential mutations
+		updatedQueue, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), createdQueue.Name, metav1.GetOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Update queue status to Open (since status is typically set by controller)
+		updatedQueue.Status.State = schedulingv1beta1.QueueStateOpen
+		_, err = testCtx.Vcclient.SchedulingV1beta1().Queues().UpdateStatus(context.TODO(), updatedQueue, metav1.UpdateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Now create PodGroup that references this queue
+		podGroup := &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      "test-podgroup-valid",
+			},
+			Spec: schedulingv1beta1.PodGroupSpec{
+				Queue:             "test-queue-open",
+				MinMember:         1,
+				PriorityClassName: "",
+			},
+		}
+
+		_, err = testCtx.Vcclient.SchedulingV1beta1().PodGroups(testCtx.Namespace).Create(context.TODO(), podGroup, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.SchedulingV1beta1().PodGroups(testCtx.Namespace).Delete(context.TODO(), podGroup.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queue.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	// Test PodGroup creation without queue (should succeed)
+	ginkgo.It("Should allow PodGroup creation without queue specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// Create PodGroup without specifying queue
+		podGroup := &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.Namespace,
+				Name:      "test-podgroup-no-queue",
+			},
+			Spec: schedulingv1beta1.PodGroupSpec{
+				Queue:             "", // Empty queue
+				MinMember:         1,
+				PriorityClassName: "",
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().PodGroups(testCtx.Namespace).Create(context.TODO(), podGroup, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.SchedulingV1beta1().PodGroups(testCtx.Namespace).Delete(context.TODO(), podGroup.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+})

--- a/test/e2e/admission/queue_mutate_test.go
+++ b/test/e2e/admission/queue_mutate_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("Queue Mutating E2E Test", func() {
+
+	ginkgo.It("Should set default reclaimable to true when not specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default-reclaimable-queue",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				// Reclaimable not specified
+			},
+		}
+
+		createdQueue, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdQueue.Spec.Reclaimable).NotTo(gomega.BeNil())
+		gomega.Expect(*createdQueue.Spec.Reclaimable).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("Should set default weight to 1 when not specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		trueValue := true
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default-weight-queue",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				// Weight not specified (defaults to 0)
+				Reclaimable: &trueValue,
+			},
+		}
+
+		createdQueue, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdQueue.Spec.Weight).To(gomega.Equal(int32(1)))
+	})
+
+	ginkgo.It("Should apply both default reclaimable and weight when not specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "both-defaults-queue",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				// Both Weight and Reclaimable not specified
+			},
+		}
+
+		createdQueue, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(createdQueue.Spec.Weight).To(gomega.Equal(int32(1)))
+		gomega.Expect(createdQueue.Spec.Reclaimable).NotTo(gomega.BeNil())
+		gomega.Expect(*createdQueue.Spec.Reclaimable).To(gomega.BeTrue())
+	})
+
+	ginkgo.It("Should preserve existing field values when specified", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		falseValue := false
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "preserve-values-queue",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight:      5,           // Explicitly specified
+				Reclaimable: &falseValue, // Explicitly specified as false
+			},
+		}
+
+		createdQueue, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Should preserve explicitly specified values
+		gomega.Expect(createdQueue.Spec.Weight).To(gomega.Equal(int32(5)))
+		gomega.Expect(createdQueue.Spec.Reclaimable).NotTo(gomega.BeNil())
+		gomega.Expect(*createdQueue.Spec.Reclaimable).To(gomega.BeFalse())
+	})
+
+	// Note: We are not testing hierarchy root prefix addition in e2e tests because:
+	// 1. The validation policy runs before the mutating webhook
+	// 2. The validation requires exact segment count matching before mutation can occur
+	// 3. This functionality is already covered by unit tests which test the webhook logic directly
+	// 4. In practice, users should provide properly formatted hierarchy annotations
+})

--- a/test/e2e/admission/queue_validation_test.go
+++ b/test/e2e/admission/queue_validation_test.go
@@ -1,0 +1,542 @@
+/*
+Copyright 2025 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
+	"volcano.sh/volcano/test/e2e/util"
+)
+
+var _ = ginkgo.Describe("Queue Validating E2E Test", func() {
+
+	// Test basic queue creation with valid configurations
+	ginkgo.It("Should allow queue creation with valid state (Open)", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-open",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+			Status: schedulingv1beta1.QueueStatus{
+				State: schedulingv1beta1.QueueStateOpen,
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queue.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow queue creation with valid state (Closed)", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-closed-queue",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+			Status: schedulingv1beta1.QueueStatus{
+				State: schedulingv1beta1.QueueStateClosed,
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queue.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow queue creation without state set", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-no-state",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queue.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	// Test resource validation
+	ginkgo.It("Should allow queue creation with only deserved resource", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-deserved-only",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Deserved: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queue.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should allow queue creation with only guarantee resource", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-guarantee-only",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Guarantee: schedulingv1beta1.Guarantee{
+					Resource: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1"),
+						v1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queue.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject queue creation with capability less than deserved", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-capability-less-deserved",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Capability: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Deserved: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("deserved should less equal than capability"))
+	})
+
+	ginkgo.It("Should reject queue creation with capability less than guarantee", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-capability-less-guarantee",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Capability: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Guarantee: schedulingv1beta1.Guarantee{
+					Resource: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("guarantee should less equal than capability"))
+	})
+
+	ginkgo.It("Should reject queue creation with deserved less than guarantee", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-deserved-less-guarantee",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Deserved: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Guarantee: schedulingv1beta1.Guarantee{
+					Resource: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("3Gi"),
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("guarantee should less equal than deserved"))
+	})
+
+	// Test resource type validation - resources in deserved/guarantee must exist in capability
+	ginkgo.It("Should reject queue creation with deserved resource type not in capability", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-deserved-type-not-in-capability",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Capability: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("10"),
+				},
+				Deserved: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("5"),
+					v1.ResourceMemory: resource.MustParse("10Gi"),
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("deserved should less equal than capability"))
+	})
+
+	ginkgo.It("Should reject queue creation with guarantee resource type not in capability", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-guarantee-type-not-in-capability",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Capability: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("10"),
+				},
+				Guarantee: schedulingv1beta1.Guarantee{
+					Resource: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("5"),
+						v1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("guarantee should less equal than capability"))
+	})
+
+	ginkgo.It("Should reject queue creation with guarantee resource type not in deserved", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-guarantee-type-not-in-deserved",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Deserved: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("10"),
+				},
+				Guarantee: schedulingv1beta1.Guarantee{
+					Resource: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("5"),
+						v1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				},
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("guarantee should less equal than deserved"))
+	})
+
+	// Test hierarchical queue annotations
+	ginkgo.It("Should reject queue creation with only hierarchy annotation but no weights", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "hierarchy-only-queue",
+				Annotations: map[string]string{
+					schedulingv1beta1.KubeHierarchyAnnotationKey: "a",
+					// KubeHierarchyWeightAnnotationKey not specified - this should fail validation
+				},
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+
+		// This should fail due to validation policy requiring both annotations
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("denied"))
+	})
+
+	ginkgo.It("Should reject queue creation with mismatched hierarchy annotation lengths", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mismatched-hierarchy-queue",
+				Annotations: map[string]string{
+					schedulingv1beta1.KubeHierarchyAnnotationKey:       "a/b",   // 2 segments
+					schedulingv1beta1.KubeHierarchyWeightAnnotationKey: "1/2/3", // 3 segments - mismatch
+				},
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+
+		// This should fail due to validation policy requiring matching lengths
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("must have the same length"))
+	})
+
+	ginkgo.It("Should reject queue creation with mismatched hierarchy and weights", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-hierarchy-mismatch",
+				Annotations: map[string]string{
+					schedulingv1beta1.KubeHierarchyAnnotationKey:       "root/a/b",
+					schedulingv1beta1.KubeHierarchyWeightAnnotationKey: "1/2/3/4",
+				},
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("must have the same length"))
+	})
+
+	ginkgo.It("Should reject queue creation with negative hierarchical weight", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-negative-hierarchy-weight",
+				Annotations: map[string]string{
+					schedulingv1beta1.KubeHierarchyAnnotationKey:       "root/a/b",
+					schedulingv1beta1.KubeHierarchyWeightAnnotationKey: "1/-1/3",
+				},
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("Should reject queue creation with invalid hierarchical weight format", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-invalid-hierarchy-weight",
+				Annotations: map[string]string{
+					schedulingv1beta1.KubeHierarchyAnnotationKey:       "root/a/b",
+					schedulingv1beta1.KubeHierarchyWeightAnnotationKey: "1/a/3",
+				},
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+
+	// Test queue update scenarios
+	ginkgo.It("Should allow queue state update from Open to Closed", func() {
+		queueName := "test-queue-update-state"
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// Create queue with Open state
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: queueName,
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+			Status: schedulingv1beta1.QueueStatus{
+				State: schedulingv1beta1.QueueStateOpen,
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Retry update with fresh object on conflict
+		var updateErr error
+		for retryCount := 0; retryCount < 5; retryCount++ {
+			// Fetch the latest version before updating
+			latestQueue, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Get(context.TODO(), queueName, metav1.GetOptions{})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Update to Closed state
+			latestQueue.Status.State = schedulingv1beta1.QueueStateClosed
+
+			_, updateErr = testCtx.Vcclient.SchedulingV1beta1().Queues().Update(context.TODO(), latestQueue, metav1.UpdateOptions{})
+			// If we get a conflict, retry with fresh object
+			if errors.IsConflict(updateErr) {
+				continue
+			}
+			// For any other error or success, break
+			break
+		}
+
+		gomega.Expect(updateErr).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queueName, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	// Test queue deletion scenarios
+	ginkgo.It("Should allow deletion of regular queues", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		queue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-queue-deletable",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), queue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), queue.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	// Test hierarchical queue scenarios
+	ginkgo.It("Should allow hierarchical queue creation with valid parent", func() {
+		testCtx := util.InitTestContext(util.Options{})
+		defer util.CleanupTestContext(testCtx)
+
+		// Create parent queue first
+		parentQueue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-parent-queue",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Parent: "root",
+			},
+		}
+
+		_, err := testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), parentQueue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Create child queue
+		childQueue := &schedulingv1beta1.Queue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-child-queue",
+			},
+			Spec: schedulingv1beta1.QueueSpec{
+				Weight: 1,
+				Parent: "test-parent-queue",
+			},
+		}
+
+		_, err = testCtx.Vcclient.SchedulingV1beta1().Queues().Create(context.TODO(), childQueue, metav1.CreateOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Cleanup
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), childQueue.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = testCtx.Vcclient.SchedulingV1beta1().Queues().Delete(context.TODO(), parentQueue.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
…ngAdmissionPolicy

- Add E2E workflows for admission policy and webhook validation
- Introduce new Makefile targets for admission policy testing
- Enable MutatingAdmissionPolicy feature gate in kind configuration
- Update Kubernetes API server flags to support admission policies
- Generate YAML manifests with VAP and MAP enablement options
- Upgrade kind version from v0.29.0 to v0.30.0
- Add admission policy definitions for hypernodes, jobflows, jobs, and podgroups
- Implement mutating policies for job and podgroup resources
- Include comprehensive validation rules using CEL expressions
- Add E2E test cases for admission policy validation
- Configure helm charts to conditionally include policy templates
- Extend run-e2e-kind.sh to handle admission policy test scenarios

#### What type of PR is this?

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
Notice that do not add `Fixes` if the issue is associated with multiple PRs.
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```